### PR TITLE
feat: add deployment docs

### DIFF
--- a/capstart-website/content/docs/deployment.mdx
+++ b/capstart-website/content/docs/deployment.mdx
@@ -1,0 +1,85 @@
+---
+title: Deployment
+description: Prepare, build, and update a Capacitor app for iOS and Android.
+---
+
+Deploying a Capacitor app has two different rhythms:
+
+- **Store releases** for the native shell: plugins, permissions, signing, app icons, entitlements, Android manifests, iOS capabilities, and anything that changes the app installed from the stores.
+- **Web updates** for the code that lives inside the WebView: HTML, CSS, JavaScript, copy, routes, API calls, and most product UI changes.
+
+The important habit is to decide which rhythm your change actually needs. Many updates look like mobile work from the user side, but they are still web bundle changes technically.
+
+## Store Release Checklist
+
+Use a normal App Store or Play Store release when the native project changes, when the first version of the app goes live, or when the app must request new native capabilities.
+
+```bash
+npm run build
+npx cap sync
+```
+
+Then open the native project you are shipping:
+
+```bash
+npx cap open ios
+npx cap open android
+```
+
+Before archiving, check the boring details that usually cause review or build delays:
+
+- `appId` and `appName` are final in `capacitor.config.ts`.
+- Production environment variables are used for the build.
+- iOS version/build numbers and Android version codes were bumped.
+- Icons, splash screens, permissions, deep links, and signing certificates match the app you want to submit.
+- The release build was tested on a real device, not only in the browser.
+
+## When a Live Update Is Enough
+
+Most day-to-day changes in a Capacitor app are changes to the web bundle: UI layout, text, styling, screens, client-side state, API integration, and JavaScript behavior that does not require a new native plugin or permission.
+
+For those changes, I usually prefer a live update workflow instead of submitting a full native build again. It keeps small product iterations closer to a web deployment cycle while the installed native shell stays the same.
+
+Live updates are not a way to bypass store rules. Use them for web assets that are already supported by the app version users have installed. If a change adds native behavior, changes permissions, modifies entitlements, or needs a new plugin, ship a store release.
+
+| Change | Usually ship with |
+| --- | --- |
+| Copy, layout, CSS, route, screen, or JavaScript change | Live update |
+| API integration change using existing native capabilities | Live update |
+| New Capacitor plugin or native SDK | Store release |
+| New iOS entitlement, Android permission, deep link, widget, or push setup | Store release |
+| App icon, splash screen, bundle identifier, signing, or version metadata | Store release |
+
+<div className="not-prose my-6 flex flex-col gap-3 rounded-lg border border-fd-border bg-fd-card p-4 sm:flex-row sm:items-center sm:justify-between">
+  <p className="text-sm leading-relaxed text-fd-muted-foreground">
+    Capgo is one way to manage this live update workflow for Capacitor apps, especially when the release only changes the web bundle.
+  </p>
+  <a
+    href="https://capgo.app"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex shrink-0 items-center justify-center rounded-md border border-fd-border px-3 py-2 text-sm font-medium text-fd-foreground transition-colors hover:bg-fd-muted"
+  >
+    Open Capgo
+  </a>
+</div>
+
+## A Simple Release Flow
+
+For a native release:
+
+```bash
+npm run build
+npx cap sync
+npx cap open ios
+```
+
+Archive from Xcode, upload to App Store Connect, then repeat the equivalent Android release from Android Studio or your CI.
+
+For a web-only update:
+
+```bash
+npm run build
+```
+
+Publish the generated web bundle through your live update tool, then test the installed app on the channel or environment that will receive the update.

--- a/capstart-website/content/docs/index.mdx
+++ b/capstart-website/content/docs/index.mdx
@@ -13,7 +13,12 @@ Use these pages to understand what each component does, when it is useful, and h
   <Card
     title="Installation"
     href="/docs/installation"
-    description="An opinionated Vite React + Capacitor setup with the base plugins and mobile libraries I recommend."
+    description="An opinionated Vite React + Capacitor setup with the base plugins and native project sync I recommend."
+  />
+  <Card
+    title="Deployment"
+    href="/docs/deployment"
+    description="A practical release flow for store builds, web-only updates, and native build constraints."
   />
 </Cards>
 
@@ -74,7 +79,9 @@ Use these pages to understand what each component does, when it is useful, and h
 
 ## How To Use This Catalog
 
-Start with **Installation** if you are creating a new app from scratch. It gives you a simple baseline with Vite React, Capacitor, shadcn/ui, useful Capacitor plugins, live reload, and screen transitions.
+Start with **Installation** if you are creating a new app from scratch. It gives you a simple baseline with Vite React, Capacitor, shadcn/ui, useful Capacitor plugins, and native project sync.
+
+Then read **Deployment** before your first release. Store builds and web-only updates do not have the same cost, and the right path depends on whether the native shell changed.
 
 Then add components only when they solve a real mobile problem. Some apps only need Tailwind and a few Capacitor plugins. Others benefit from native surfaces, platform-aware transitions, or a native app frame.
 

--- a/capstart-website/content/docs/installation.mdx
+++ b/capstart-website/content/docs/installation.mdx
@@ -57,16 +57,6 @@ After cloning, fill the Supabase values in `.env`, then update `appId` and `appN
 
 [Open Capstart on GitHub](https://github.com/AdrienADV/capstart)
 
-<div className="not-prose mt-2 rounded-xl border border-fd-primary/20 bg-fd-primary/5 px-6 py-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-  <div className="flex flex-col gap-1.5">
-    <p className="font-semibold text-fd-foreground text-sm">Tired of waiting 3 days for Apple to approve your update?</p>
-    <p className="text-xs text-fd-muted-foreground leading-relaxed">Push updates in <strong className="text-fd-foreground">minutes</strong>, not days — no store review, no waiting. Capgo delivers live updates to your Capacitor app instantly.</p>
-  </div>
-  <a href="https://capgo.app" target="_blank" rel="noopener noreferrer" className="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-fd-primary text-fd-primary-foreground font-semibold text-xs hover:opacity-90 transition-opacity whitespace-nowrap shadow-md shadow-fd-primary/20">
-    Try Capgo for free →
-  </a>
-</div>
-
 ## Manual setup
 
 ## 1. Create a Vite React app
@@ -204,77 +194,19 @@ This starter configures Tailwind and the `@/` alias, but it does not duplicate t
 
 Use that page as the source of truth for the current `shadcn` commands and component setup.
 
-## 6. Add the mobile-specific layer
+## 6. Sync and open the native projects
 
-Install **only the pieces your app actually needs**:
+At this point, keep the installation focused on the stable base: the web app, Capacitor, Tailwind, aliases, and the small set of native plugins you know you need.
+
+Build the web bundle, sync it into the native projects, then open the platform you want to test:
 
 ```bash
-npm install @capgo/vite-capacitor @capgo/capacitor-transitions
+npm run build
 npx cap sync
+npx cap open ios
+npx cap open android
 ```
 
-For `@capgo/vite-capacitor`, add the Vite plugin so Capacitor can automatically point the native app to your local Vite server during development:
+You do not have to make every surface native from day one. A Tailwind bottom bar is enough for many apps, and you can add native-feeling transitions, native bars, social login, purchases, widgets, or other mobile-specific pieces later when the product actually needs them.
 
-```ts title="vite.config.ts"
-import viteCapacitor from '@capgo/vite-capacitor';
-import tailwindcss from '@tailwindcss/vite';
-import react from '@vitejs/plugin-react';
-import path from 'node:path';
-import { defineConfig } from 'vite';
-
-export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-    viteCapacitor({
-      platforms: ['ios', 'android'],
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-});
-```
-
-Then start Vite normally:
-
-```bash
-npm run dev
-```
-
-For testing on a physical device, expose Vite on your local network and ask the plugin to use the LAN URL:
-
-```ts title="vite.config.ts"
-viteCapacitor({
-  platforms: ['ios', 'android'],
-  cleartext: true,
-  networkUrl: true,
-});
-```
-
-```bash
-npm run dev -- --host 0.0.0.0
-```
-
-The shared `capacitor.config.ts` stays simple. The plugin updates the native copies created by Capacitor, then restores them when Vite stops.
-
-Recommended roles:
-
-| Library | Use it for |
-| --- | --- |
-| `@capgo/vite-capacitor` | The simplest **live reload loop** while testing the app inside a native Capacitor shell. |
-| `@capgo/capacitor-transitions` | **Screen transitions** that feel closer to iOS and Android while your web router still owns navigation. |
-
-**You do not have to make every surface native.** For this starter, keep navigation simple: a **Tailwind bottom bar is enough for most apps**, while `@capgo/capacitor-transitions` handles the screen transitions.
-
-<div className="not-prose mt-8 rounded-xl border border-fd-primary/20 bg-fd-primary/5 px-6 py-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-  <div className="flex flex-col gap-1.5">
-    <p className="font-semibold text-fd-foreground text-sm">Your app is ready to ship. Don't let Apple slow you down.</p>
-    <p className="text-xs text-fd-muted-foreground leading-relaxed">Push updates to your users in <strong className="text-fd-foreground">minutes</strong>, not days — no store review, no waiting. Capgo delivers live updates to your Capacitor app instantly.</p>
-  </div>
-  <a href="https://capgo.app" target="_blank" rel="noopener noreferrer" className="shrink-0 inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-fd-primary text-fd-primary-foreground font-semibold text-xs hover:opacity-90 transition-opacity whitespace-nowrap shadow-md shadow-fd-primary/20">
-    Try Capgo for free →
-  </a>
-</div>
+After installation, read the [Deployment](/docs/deployment) page before your first release. It explains when to submit a new store build and when a web-only update can be enough.

--- a/capstart-website/content/docs/meta.json
+++ b/capstart-website/content/docs/meta.json
@@ -3,6 +3,7 @@
     "---Getting Started---",
     "index",
     "installation",
+    "deployment",
     "---Components---",
     "transitions",
     "native-bar",

--- a/capstart-website/src/routes/index.tsx
+++ b/capstart-website/src/routes/index.tsx
@@ -30,7 +30,7 @@ function Home() {
                 of UI components built for CapacitorJS. Whether you're
                 targeting iOS, Android or the web, you'll find
                 production-ready components that feel native on every
-                platform — backed by real-world usage in the Capgo ecosystem.
+                platform.
               </p>
 
               <div className="flex flex-wrap items-center justify-center lg:justify-start gap-4">
@@ -275,9 +275,9 @@ function Home() {
                       className="w-8 h-8 object-contain"
                     />
                   ),
-                  title: 'Ship without waiting',
+                  title: 'Ship with live updates',
                   description:
-                    "Don't wait 2–3 days for Apple validation to ship a new feature — use Capgo.",
+                    'Do not wait 2-3 days for App Store review to ship a web-only change: use a live update when the native shell is unchanged.',
                 },
               ].map((feature) => (
                 <div


### PR DESCRIPTION
## Summary
- Add a Deployment docs page for store releases and web-only updates.
- Move release guidance out of the Installation page.
- Update the docs index and homepage copy to point users toward the new release flow.

## Validation
- `npm run types:check`
- `npm run build`