### PR TITLE
fix(website): point GitHub links to capstart repo

### DIFF
--- a/capstart-website/src/lib/shared.ts
+++ b/capstart-website/src/lib/shared.ts
@@ -4,6 +4,6 @@ export const docsImageRoute = '/og/docs';
 
 export const gitConfig = {
   user: 'AdrienADV',
-  repo: 'capstart-docs',
+  repo: 'capstart',
   branch: 'main',
 };


### PR DESCRIPTION
## Summary
- Update `gitConfig.repo` from `capstart-docs` to `capstart` so the Fumadocs header GitHub icon and docs “edit on GitHub” links resolve correctly.
- Fixes 404 on the top-right GitHub link on the homepage.

## Test plan
- [ ] Open the website homepage and click the GitHub icon (top right) — should open https://github.com/AdrienADV/capstart
- [ ] Open a docs page and verify the GitHub/edit link targets the `capstart` repo on `main`


Made with [Cursor](https://cursor.com)