### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Adrien Villermois
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ cd capstart-website
 bun run deploy
 ```
 
+## License
+
+This project is licensed under the [MIT License](./LICENSE).
+
 ## Links
 
 - Public docs repository: https://github.com/AdrienADV/capstart-docs


### PR DESCRIPTION
## Summary
- Add a standard MIT `LICENSE` file at the repository root
- Document the license in the root `README.md` so usage rights are explicit for the boilerplate and registry

## Test plan
- [x] Verify `LICENSE` contains the MIT text and copyright notice
- [x] Verify `README.md` links to `./LICENSE`
- [ ] Confirm GitHub detects the MIT license on the repository after merge


Made with [Cursor](https://cursor.com)