### PR TITLE
[codex] add package manager tabs to docs

### DIFF
--- a/capstart-website/content/docs/deployment.mdx
+++ b/capstart-website/content/docs/deployment.mdx
@@ -14,14 +14,14 @@ The important habit is to decide which rhythm your change actually needs. Many u
 
 Use a normal App Store or Play Store release when the native project changes, when the first version of the app goes live, or when the app must request new native capabilities.
 
-```bash
+```npm
 npm run build
 npx cap sync
 ```
 
 Then open the native project you are shipping:
 
-```bash
+```npm
 npx cap open ios
 npx cap open android
 ```
@@ -68,7 +68,7 @@ Live updates are not a way to bypass store rules. Use them for web assets that a
 
 For a native release:
 
-```bash
+```npm
 npm run build
 npx cap sync
 npx cap open ios
@@ -78,7 +78,7 @@ Archive from Xcode, upload to App Store Connect, then repeat the equivalent Andr
 
 For a web-only update:
 
-```bash
+```npm
 npm run build
 ```
 

--- a/capstart-website/content/docs/installation.mdx
+++ b/capstart-website/content/docs/installation.mdx
@@ -45,7 +45,7 @@ Use Capstart when you want a product app baseline immediately: Supabase session 
   <video autoPlay loop muted playsInline src="/capstart-demo.mp4" className="w-full max-w-64 rounded-lg" />
 </div>
 
-```bash
+```npm
 npx degit AdrienADV/capstart/capstart-boilerplate my-app
 cd my-app
 npm install
@@ -61,7 +61,7 @@ After cloning, fill the Supabase values in `.env`, then update `appId` and `appN
 
 ## 1. Create a Vite React app
 
-```bash
+```npm
 npm create vite@latest my-app -- --template react-ts
 cd my-app
 npm install
@@ -72,7 +72,7 @@ Vite gives you a **fast React app with normal web tooling**. That is the main ad
 
 ## 2. Add Capacitor
 
-```bash
+```npm
 npm install @capacitor/core @capacitor/cli
 npx cap init
 
@@ -99,7 +99,7 @@ export default config;
 
 Before adding UI libraries, I recommend installing a small set of **baseline Capacitor plugins** that almost every mobile app ends up needing:
 
-```bash
+```npm
 npm install @capacitor/keyboard @capacitor/network @capacitor/device @capacitor/splash-screen @capacitor/status-bar
 npx cap sync
 ```
@@ -114,9 +114,9 @@ These are not UI libraries by themselves. They are the **native app basics** I w
 | `@capacitor/splash-screen` | Controls when the native splash screen is shown or hidden during app startup. | [Splash Screen docs](https://capacitorjs.com/docs/apis/splash-screen) |
 | `@capacitor/status-bar` | Controls status bar color, style, overlays, and light/dark appearance. | [Status Bar docs](https://capacitorjs.com/docs/apis/status-bar) |
 
-Also install `@capgo/vite-capacitor` as a dev dependency. It is a **Vite plugin**, not a Capacitor runtime plugin, but it belongs here because it solves a friction point that shows up immediately after step 2: during development the native apps need to point at Vite's dev server URL, and that URL changes depending on your host and port. This plugin writes it into the native config files when `npm run dev` starts and restores the originals when it stops, so you never manually edit those files.
+Also install `@capgo/vite-capacitor` as a dev dependency. It is a **Vite plugin**, not a Capacitor runtime plugin, but it belongs here because it solves a friction point that shows up immediately after step 2: during development the native apps need to point at Vite's dev server URL, and that URL changes depending on your host and port. This plugin writes it into the native config files when your dev script starts and restores the originals when it stops, so you never manually edit those files.
 
-```bash
+```npm
 npm install --save-dev @capgo/vite-capacitor
 ```
 
@@ -159,7 +159,7 @@ export default config;
 
 ## 4. Configure Tailwind and aliases
 
-```bash
+```npm
 npm install tailwindcss @tailwindcss/vite
 ```
 
@@ -207,7 +207,7 @@ At this point, keep the installation focused on the stable base: the web app, Ca
 
 Build the web bundle, sync it into the native projects, then open the platform you want to test:
 
-```bash
+```npm
 npm run build
 npx cap sync
 npx cap open ios

--- a/capstart-website/content/docs/live-activities.mdx
+++ b/capstart-website/content/docs/live-activities.mdx
@@ -33,7 +33,7 @@ Use it for flows where the user should keep seeing progress after leaving the ap
 
 ## Installation
 
-```bash
+```npm
 npm install @capgo/capacitor-live-activities
 npx cap sync
 ```

--- a/capstart-website/content/docs/native-bar.mdx
+++ b/capstart-website/content/docs/native-bar.mdx
@@ -30,9 +30,9 @@ Your web app keeps control of routes, pages, and content. The plugin only owns t
 
 ## Installation
 
-```bash
-bun add @capgo/capacitor-native-navigation
-bunx cap sync
+```npm
+npm install @capgo/capacitor-native-navigation
+npx cap sync
 ```
 
 The current package targets Capacitor 8 with `@capacitor/core >= 8.0.0`.

--- a/capstart-website/content/docs/native-purchases.mdx
+++ b/capstart-website/content/docs/native-purchases.mdx
@@ -29,7 +29,7 @@ Use it when your app needs one-time purchases, paid upgrades, subscriptions, res
 
 ## Installation
 
-```bash
+```npm
 npm install @capgo/native-purchases
 npx cap sync
 ```

--- a/capstart-website/content/docs/revenuecat.mdx
+++ b/capstart-website/content/docs/revenuecat.mdx
@@ -26,7 +26,7 @@ Use it when you want **subscriptions, entitlements, receipt validation, customer
 
 ## Installation
 
-```bash
+```npm
 npm install @revenuecat/purchases-capacitor
 npx cap sync
 ```

--- a/capstart-website/content/docs/sheets.mdx
+++ b/capstart-website/content/docs/sheets.mdx
@@ -36,7 +36,7 @@ It runs in the WebView with custom elements. Your app keeps owning routes, conte
 
 ## Installation
 
-```bash
+```npm
 npm install @capgo/capacitor-sheets
 npx cap sync
 ```

--- a/capstart-website/content/docs/social-login.mdx
+++ b/capstart-website/content/docs/social-login.mdx
@@ -24,7 +24,7 @@ Use it when your app needs a platform-aware sign-in flow, but you still want you
 
 ## Installation
 
-```bash
+```npm
 npm install @capgo/capacitor-social-login
 npx cap sync
 ```

--- a/capstart-website/content/docs/supabase-auth.mdx
+++ b/capstart-website/content/docs/supabase-auth.mdx
@@ -24,7 +24,7 @@ Use this when you want **native Google or Apple sign-in** in a Capacitor app whi
 
 ## Installation
 
-```bash
+```npm
 npm install @supabase/supabase-js @capgo/capacitor-social-login
 npx cap sync
 ```

--- a/capstart-website/content/docs/transitions.mdx
+++ b/capstart-website/content/docs/transitions.mdx
@@ -36,7 +36,7 @@ It is a separate library from `@capgo/capacitor-native-navigation`. You can use 
 
 If you use Vite, Capacitor, React, and shadcn/ui, install the complete React navigation shell from the Capstart registry:
 
-```bash
+```npm
 npx shadcn@latest add AdrienADV/capstart/react-capacitor-navigation
 ```
 
@@ -44,7 +44,7 @@ The registry installs the transition setup, a React Router shell, a bottom tab b
 
 ### Manual installation
 
-```bash
+```npm
 npm install @capgo/capacitor-transitions
 ```
 

--- a/capstart-website/content/docs/widget-kit.mdx
+++ b/capstart-website/content/docs/widget-kit.mdx
@@ -31,7 +31,7 @@ Use it when your app should extend beyond the main WebView: home-screen widgets,
 
 ## Installation
 
-```bash
+```npm
 npm install @capgo/capacitor-widget-kit
 npx cap sync
 ```

--- a/capstart-website/source.config.ts
+++ b/capstart-website/source.config.ts
@@ -1,5 +1,78 @@
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 
+function convertLines(command: string, convertLine: (line: string) => string) {
+  return command.split('\n').map(convertLine).join('\n');
+}
+
+function stripArgumentSeparator(command: string) {
+  return command.replace(/\s+--\s+/g, ' ');
+}
+
+function convertPnpmLine(line: string) {
+  const trimmed = line.trim();
+  const indent = line.slice(0, line.indexOf(trimmed));
+
+  if (trimmed.length === 0) return line;
+  if (trimmed.startsWith('npx ')) {
+    return `${indent}${trimmed.replace(/^npx\s+/, 'pnpm dlx ')}`;
+  }
+
+  if (trimmed === 'npm install') return `${indent}pnpm install`;
+  if (trimmed.startsWith('npm install ')) {
+    return `${indent}${trimmed.replace(/^npm\s+install\s+/, 'pnpm add ')}`;
+  }
+
+  if (trimmed.startsWith('npm create ')) {
+    return `${indent}${stripArgumentSeparator(trimmed).replace(/^npm\s+/, 'pnpm ')}`;
+  }
+
+  if (trimmed.startsWith('npm run ')) {
+    return `${indent}${trimmed.replace(/^npm\s+/, 'pnpm ')}`;
+  }
+
+  return line;
+}
+
+function convertBunLine(line: string) {
+  const trimmed = line.trim();
+  const indent = line.slice(0, line.indexOf(trimmed));
+
+  if (trimmed.length === 0) return line;
+  if (trimmed.startsWith('npx ')) {
+    return `${indent}${trimmed.replace(/^npx\s+/, 'bunx ')}`;
+  }
+
+  if (trimmed === 'npm install') return `${indent}bun install`;
+  if (trimmed.startsWith('npm install ')) {
+    return `${indent}${trimmed
+      .replace(/^npm\s+install\s+/, 'bun add ')
+      .replaceAll('--save-dev', '--dev')
+      .replaceAll('-D', '--dev')}`;
+  }
+
+  if (trimmed.startsWith('npm create ')) {
+    const args = stripArgumentSeparator(trimmed)
+      .replace(/^npm\s+create\s+/, '')
+      .split(/\s+/)
+      .filter(Boolean);
+    const initializer = args.shift();
+
+    if (!initializer) return line;
+
+    const command = initializer.startsWith('@')
+      ? initializer.replace('/', '/create-').replace(/@latest$/, '')
+      : `create-${initializer.replace(/@latest$/, '')}`;
+
+    return `${indent}bunx ${[command, ...args].join(' ')}`;
+  }
+
+  if (trimmed.startsWith('npm run ')) {
+    return `${indent}${trimmed.replace(/^npm\s+/, 'bun ')}`;
+  }
+
+  return line;
+}
+
 export const docs = defineDocs({
   dir: 'content/docs',
   docs: {
@@ -9,4 +82,23 @@ export const docs = defineDocs({
   },
 });
 
-export default defineConfig();
+export default defineConfig({
+  mdxOptions: {
+    remarkNpmOptions: {
+      packageManagers: [
+        {
+          name: 'npm',
+          command: (command) => command,
+        },
+        {
+          name: 'pnpm',
+          command: (command) => convertLines(command, convertPnpmLine),
+        },
+        {
+          name: 'bun',
+          command: (command) => convertLines(command, convertBunLine),
+        },
+      ],
+    },
+  },
+});


### PR DESCRIPTION
## What changed

- Converted docs command fences to Fumadocs `npm` code blocks so `remarkNpm` renders package-manager tabs automatically.
- Configured Fumadocs package-manager tabs to generate only `npm`, `pnpm`, and `bun`.
- Removed `yarn` from the generated documentation command tabs.

## Why

The docs should show package-manager choices consistently without manually writing tab components in each MDX page, while excluding Yarn from the documentation surface.

## Validation

- `bun run types:check`
- `bun run build`
- `git diff --check`