### PR TITLE
[codex] bump CLI version to 0.1.2

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstart",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Add Capacitor to existing web framework projects.",
   "type": "module",
   "packageManager": "bun@1.3.9",


### PR DESCRIPTION
## Summary

- bump the CLI package version from `0.1.1` to `0.1.2`
- synchronize the repository with the `capstart@0.1.2` version already present on npm

## Impact

The source package metadata now matches the currently published npm release. This PR does not republish `0.1.2`, because npm package versions are immutable.

## Validation

- `bun install`
- `bun run typecheck`
- `bun test` (19 tests)
- `bun run build`
- `bun publish --dry-run`