### PR TITLE
[codex] Add recommended setup and safe area support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ npx capstart init ..
 
 The CLI displays the detected framework and asks for confirmation before
 configuring the project. If detection is refused, it offers Next.js and
-TanStack Start as explicit choices.
+TanStack Start as explicit choices. It also offers a minimal setup or a
+recommended setup that includes common Capacitor plugins for keyboard, network,
+device, splash screen, and status bar behavior.
 
 Useful path:
 - `cli/README.md`

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,6 +10,15 @@ Capstart detects the framework and package manager, configures a static or SPA
 build, installs Capacitor, adds native projects, builds the web application, and
 runs `cap sync`.
 
+In an interactive terminal, Capstart also asks which setup to install:
+
+- `minimal`: Capacitor core, CLI, and the selected native platforms;
+- `recommended`: the minimal setup plus Keyboard, Network, Device, Splash
+  Screen, and Status Bar plugins.
+
+The recommended setup is pre-selected in the interactive prompt. Non-interactive
+usage keeps the existing minimal setup unless `--setup recommended` is passed.
+
 Installation, build, and Capacitor command output is hidden by default. Capstart
 shows a single setup progress line and only prints a short command summary when
 something fails.
@@ -19,7 +28,8 @@ Each main installation operation has its own step:
 ```text
 ◇ Configure Next.js
 ◇ Configure Capacitor
-◇ Install Capacitor packages
+◇ Configure safe area insets
+◇ Install Capacitor packages (recommended)
 ◇ Build the web app
 ◇ Prepare iOS and Android projects
 ◇ Synchronize native projects
@@ -41,7 +51,8 @@ TanStack Start.
 ## Supported frameworks
 
 - Next.js projects that can use static export
-- TanStack Start projects that can use SPA mode
+- TanStack Start projects that can use SPA mode. Capstart uses `.output/public`
+  when the Vite config includes Nitro, and `dist/client` otherwise.
 
 Server-only features must remain hosted remotely and be called from the mobile
 application over HTTP.
@@ -58,6 +69,7 @@ Examples:
 npx capstart init .
 npx capstart init ../my-app --app-id com.example.myapp
 npx capstart init . --platforms ios
+npx capstart init . --setup recommended
 npx capstart init . --framework tanstack-start --dry-run
 npx capstart init . --yes
 ```
@@ -69,6 +81,9 @@ Useful options:
 --app-id <id>
 --app-name <name>
 --platforms <ios,android>
+--setup <minimal|recommended>
+--safe-area
+--no-safe-area
 --skip-install
 --skip-build
 --skip-native
@@ -80,6 +95,36 @@ Use `--yes` to accept a single automatically detected framework in CI or other
 non-interactive environments. Use `--framework` to bypass detection
 confirmation and select an adapter explicitly.
 
+Use `--setup recommended` to install these baseline runtime plugins:
+
+```text
+@capacitor/keyboard
+@capacitor/network
+@capacitor/device
+@capacitor/splash-screen
+@capacitor/status-bar
+```
+
+The recommended setup also adds baseline `Keyboard`, `SplashScreen`, and
+`StatusBar` options to `capacitor.config.ts`. Existing plugin configuration is
+merged so unrelated plugins and properties are preserved.
+
+Capstart can also add global top and bottom safe area padding. It uses the
+Capacitor 8 System Bars variables with browser fallbacks:
+
+```css
+html {
+  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));
+  padding-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));
+}
+```
+
+When selected, Capstart configures `SystemBars.insetsHandling` as `css` and adds
+`viewport-fit=cover`. Use `--safe-area` or `--no-safe-area` to bypass the
+interactive question. See the
+[Capacitor 8 System Bars documentation](https://capacitorjs.com/docs/apis/system-bars)
+for the underlying edge-to-edge behavior.
+
 After a successful interactive initialization, Capstart detects whether GitHub
 CLI is installed and optionally proposes starring
 [AdrienADV/capstart](https://github.com/AdrienADV/capstart). The repository is
@@ -88,7 +133,7 @@ only starred after explicit confirmation, and this step never runs in CI.
 The final output includes:
 
 - the scripts added to `package.json` and a short explanation of each one;
-- recommended Capacitor packages and production guidance at
+- recommended Capacitor packages, native configuration, and production guidance at
   [capstart.dev/docs/installation/#3-add-recommended-capacitor-base-plugins](https://capstart.dev/docs/installation/#3-add-recommended-capacitor-base-plugins);
 - an `Important` section explaining which framework server features must remain
   remotely hosted.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstart",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Add Capacitor to existing web framework projects.",
   "type": "module",
   "packageManager": "bun@1.3.9",

--- a/cli/src/adapters/nextjs.ts
+++ b/cli/src/adapters/nextjs.ts
@@ -21,10 +21,13 @@ const configNames = [
 export const nextjsAdapter: FrameworkAdapter = {
   id: "nextjs",
   label: "Next.js",
-  webDir: "out",
 
   detect(project) {
     return hasDependency(project, "next");
+  },
+
+  resolveWebDir() {
+    return "out";
   },
 
   async validate(project) {

--- a/cli/src/adapters/tanstack-start.ts
+++ b/cli/src/adapters/tanstack-start.ts
@@ -18,10 +18,17 @@ const configNames = [
 export const tanstackStartAdapter: FrameworkAdapter = {
   id: "tanstack-start",
   label: "TanStack Start",
-  webDir: "dist/client",
 
   detect(project) {
     return hasDependency(project, "@tanstack/react-start");
+  },
+
+  async resolveWebDir(project) {
+    const configPath = await findConfigFile(project.root, configNames);
+    if (configPath && usesNitro(configPath)) {
+      return ".output/public";
+    }
+    return "dist/client";
   },
 
   async validate(project) {
@@ -111,4 +118,29 @@ function findTanstackStartCall(configPath: string) {
   return loadSourceFile(configPath)
     .getDescendantsOfKind(SyntaxKind.CallExpression)
     .find((candidate) => candidate.getExpression().getText() === "tanstackStart");
+}
+
+function usesNitro(configPath: string): boolean {
+  const sourceFile = loadSourceFile(configPath);
+  const nitroNames = new Set(
+    sourceFile
+      .getImportDeclarations()
+      .filter(
+        (declaration) =>
+          declaration.getModuleSpecifierValue() === "nitro/vite",
+      )
+      .flatMap((declaration) =>
+        declaration
+          .getNamedImports()
+          .filter((namedImport) => namedImport.getName() === "nitro")
+          .map(
+            (namedImport) =>
+              namedImport.getAliasNode()?.getText() ?? namedImport.getName(),
+          ),
+      ),
+  );
+
+  return sourceFile
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .some((call) => nitroNames.has(call.getExpression().getText()));
 }

--- a/cli/src/capacitor/configure.ts
+++ b/cli/src/capacitor/configure.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   findConfigFile,
   findExportedObject,
+  getOrCreateNestedObject,
   loadSourceFile,
   setObjectProperty,
 } from "../core/ast.js";
@@ -11,7 +12,11 @@ import {
   capacitorScriptPrefix,
   packageScriptPrefix,
 } from "../core/process.js";
-import type { Platform, ProjectContext } from "../core/types.js";
+import type {
+  Platform,
+  ProjectContext,
+  SetupProfile,
+} from "../core/types.js";
 
 const configNames = [
   "capacitor.config.ts",
@@ -21,15 +26,19 @@ const configNames = [
   "capacitor.config.json",
 ];
 
+interface ConfigureCapacitorOptions {
+  appId: string;
+  appName: string;
+  dryRun: boolean;
+  platforms: Platform[];
+  safeArea: boolean;
+  setup: SetupProfile;
+  webDir: string;
+}
+
 export async function configureCapacitor(
   project: ProjectContext,
-  options: {
-    appId: string;
-    appName: string;
-    dryRun: boolean;
-    platforms: Platform[];
-    webDir: string;
-  },
+  options: ConfigureCapacitorOptions,
 ): Promise<void> {
   const configPath = await findConfigFile(project.root, configNames);
 
@@ -37,18 +46,7 @@ export async function configureCapacitor(
     if (!options.dryRun) {
       await writeFile(
         path.join(project.root, "capacitor.config.ts"),
-        [
-          'import type { CapacitorConfig } from "@capacitor/cli";',
-          "",
-          "const config: CapacitorConfig = {",
-          `  appId: ${JSON.stringify(options.appId)},`,
-          `  appName: ${JSON.stringify(options.appName)},`,
-          `  webDir: ${JSON.stringify(options.webDir)},`,
-          "};",
-          "",
-          "export default config;",
-          "",
-        ].join("\n"),
+        createCapacitorConfig(options),
       );
     }
   } else if (configPath.endsWith(".json")) {
@@ -57,6 +55,12 @@ export async function configureCapacitor(
       unknown
     >;
     config.webDir = options.webDir;
+    if (options.setup === "recommended") {
+      applyRecommendedJsonConfig(config);
+    }
+    if (options.safeArea) {
+      applySafeAreaJsonConfig(config);
+    }
     if (!options.dryRun) {
       await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
     }
@@ -69,6 +73,12 @@ export async function configureCapacitor(
       );
     }
     setObjectProperty(config, "webDir", JSON.stringify(options.webDir));
+    if (options.setup === "recommended") {
+      applyRecommendedSourceConfig(sourceFile, config);
+    }
+    if (options.safeArea) {
+      applySafeAreaSourceConfig(config);
+    }
     if (!options.dryRun) {
       await sourceFile.save();
     }
@@ -85,4 +95,183 @@ export async function configureCapacitor(
   }
 
   await savePackageJson(project, options.dryRun);
+}
+
+function createCapacitorConfig(options: ConfigureCapacitorOptions): string {
+  const lines = ['import type { CapacitorConfig } from "@capacitor/cli";'];
+
+  if (options.setup === "recommended") {
+    lines.push(
+      'import { KeyboardResize, KeyboardStyle } from "@capacitor/keyboard";',
+      'import { Style } from "@capacitor/status-bar";',
+    );
+  }
+
+  lines.push(
+    "",
+    "const config: CapacitorConfig = {",
+    `  appId: ${JSON.stringify(options.appId)},`,
+    `  appName: ${JSON.stringify(options.appName)},`,
+    `  webDir: ${JSON.stringify(options.webDir)},`,
+  );
+
+  if (options.setup === "recommended" || options.safeArea) {
+    lines.push("  plugins: {");
+    if (options.safeArea) {
+      lines.push(
+        "    SystemBars: {",
+        '      insetsHandling: "css",',
+        "    },",
+      );
+    }
+    if (options.setup === "recommended") {
+      lines.push(
+        "    Keyboard: {",
+        "      resize: KeyboardResize.Native,",
+        "      style: KeyboardStyle.Default,",
+        "      resizeOnFullScreen: true,",
+        "    },",
+        "    SplashScreen: {",
+        "      launchAutoHide: true,",
+        "      launchShowDuration: 500,",
+        "      launchFadeOutDuration: 200,",
+        '      backgroundColor: "#ffffff",',
+        "      showSpinner: false,",
+        "    },",
+        "    StatusBar: {",
+        "      overlaysWebView: false,",
+        "      style: Style.Default,",
+        '      backgroundColor: "#ffffff",',
+        "    },",
+      );
+    }
+    lines.push("  },");
+  }
+
+  lines.push("};", "", "export default config;", "");
+  return lines.join("\n");
+}
+
+function applyRecommendedSourceConfig(
+  sourceFile: ReturnType<typeof loadSourceFile>,
+  config: NonNullable<ReturnType<typeof findExportedObject>>,
+): void {
+  const useEnumImports = sourceFile.getExportAssignments().length > 0;
+  if (useEnumImports) {
+    addNamedImports(sourceFile, "@capacitor/keyboard", [
+      "KeyboardResize",
+      "KeyboardStyle",
+    ]);
+    addNamedImports(sourceFile, "@capacitor/status-bar", ["Style"]);
+  }
+
+  const plugins = getOrCreateNestedObject(config, "plugins");
+  const keyboard = getOrCreateNestedObject(plugins, "Keyboard");
+  setObjectProperty(
+    keyboard,
+    "resize",
+    useEnumImports ? "KeyboardResize.Native" : JSON.stringify("native"),
+  );
+  setObjectProperty(
+    keyboard,
+    "style",
+    useEnumImports ? "KeyboardStyle.Default" : JSON.stringify("DEFAULT"),
+  );
+  setObjectProperty(keyboard, "resizeOnFullScreen", "true");
+
+  const splashScreen = getOrCreateNestedObject(plugins, "SplashScreen");
+  setObjectProperty(splashScreen, "launchAutoHide", "true");
+  setObjectProperty(splashScreen, "launchShowDuration", "500");
+  setObjectProperty(splashScreen, "launchFadeOutDuration", "200");
+  setObjectProperty(splashScreen, "backgroundColor", JSON.stringify("#ffffff"));
+  setObjectProperty(splashScreen, "showSpinner", "false");
+
+  const statusBar = getOrCreateNestedObject(plugins, "StatusBar");
+  setObjectProperty(statusBar, "overlaysWebView", "false");
+  setObjectProperty(
+    statusBar,
+    "style",
+    useEnumImports ? "Style.Default" : JSON.stringify("DEFAULT"),
+  );
+  setObjectProperty(statusBar, "backgroundColor", JSON.stringify("#ffffff"));
+}
+
+function addNamedImports(
+  sourceFile: ReturnType<typeof loadSourceFile>,
+  moduleSpecifier: string,
+  names: string[],
+): void {
+  const existingNames = new Set(
+    sourceFile
+      .getImportDeclarations()
+      .filter(
+        (declaration) =>
+          declaration.getModuleSpecifierValue() === moduleSpecifier,
+      )
+      .flatMap((declaration) =>
+        declaration
+          .getNamedImports()
+          .filter((namedImport) => !namedImport.getAliasNode())
+          .map((namedImport) => namedImport.getName()),
+      ),
+  );
+  const missingNames = names.filter((name) => !existingNames.has(name));
+  if (missingNames.length > 0) {
+    sourceFile.addImportDeclaration({
+      moduleSpecifier,
+      namedImports: missingNames,
+    });
+  }
+}
+
+function applyRecommendedJsonConfig(config: Record<string, unknown>): void {
+  const plugins = getOrCreateRecord(config, "plugins");
+  Object.assign(getOrCreateRecord(plugins, "Keyboard"), {
+    resize: "native",
+    style: "DEFAULT",
+    resizeOnFullScreen: true,
+  });
+  Object.assign(getOrCreateRecord(plugins, "SplashScreen"), {
+    launchAutoHide: true,
+    launchShowDuration: 500,
+    launchFadeOutDuration: 200,
+    backgroundColor: "#ffffff",
+    showSpinner: false,
+  });
+  Object.assign(getOrCreateRecord(plugins, "StatusBar"), {
+    overlaysWebView: false,
+    style: "DEFAULT",
+    backgroundColor: "#ffffff",
+  });
+}
+
+function applySafeAreaSourceConfig(
+  config: NonNullable<ReturnType<typeof findExportedObject>>,
+): void {
+  const plugins = getOrCreateNestedObject(config, "plugins");
+  const systemBars = getOrCreateNestedObject(plugins, "SystemBars");
+  setObjectProperty(systemBars, "insetsHandling", JSON.stringify("css"));
+}
+
+function applySafeAreaJsonConfig(config: Record<string, unknown>): void {
+  const plugins = getOrCreateRecord(config, "plugins");
+  Object.assign(getOrCreateRecord(plugins, "SystemBars"), {
+    insetsHandling: "css",
+  });
+}
+
+function getOrCreateRecord(
+  object: Record<string, unknown>,
+  name: string,
+): Record<string, unknown> {
+  const value = object[name];
+  if (value === undefined) {
+    const created = {};
+    object[name] = created;
+    return created;
+  }
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  throw new Error(`Cannot safely merge the "${name}" configuration property.`);
 }

--- a/cli/src/capacitor/install.ts
+++ b/cli/src/capacitor/install.ts
@@ -6,16 +6,26 @@ import {
   runCommand,
   runScriptCommand,
 } from "../core/process.js";
-import type { Platform, ProjectContext } from "../core/types.js";
+import type {
+  Platform,
+  ProjectContext,
+  SetupProfile,
+} from "../core/types.js";
+
+export const recommendedCapacitorPlugins = [
+  "@capacitor/keyboard",
+  "@capacitor/network",
+  "@capacitor/device",
+  "@capacitor/splash-screen",
+  "@capacitor/status-bar",
+] as const;
 
 export async function installCapacitor(
   project: ProjectContext,
   platforms: Platform[],
+  setup: SetupProfile = "minimal",
 ): Promise<void> {
-  const runtimePackages = [
-    "@capacitor/core",
-    ...platforms.map((platform) => `@capacitor/${platform}`),
-  ];
+  const runtimePackages = getCapacitorRuntimePackages(platforms, setup);
 
   await run(project, installCommand(project.packageManager, runtimePackages, false));
 
@@ -23,6 +33,17 @@ export async function installCapacitor(
     project,
     installCommand(project.packageManager, ["@capacitor/cli"], true),
   );
+}
+
+export function getCapacitorRuntimePackages(
+  platforms: Platform[],
+  setup: SetupProfile,
+): string[] {
+  return [
+    "@capacitor/core",
+    ...platforms.map((platform) => `@capacitor/${platform}`),
+    ...(setup === "recommended" ? recommendedCapacitorPlugins : []),
+  ];
 }
 
 export async function buildProject(project: ProjectContext): Promise<void> {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -3,7 +3,11 @@
 import { Command, InvalidArgumentError } from "commander";
 import { initCommand } from "./commands/init.js";
 import { logger } from "./core/logger.js";
-import type { FrameworkId, Platform } from "./core/types.js";
+import type {
+  FrameworkId,
+  Platform,
+  SetupProfile,
+} from "./core/types.js";
 
 const program = new Command();
 
@@ -29,6 +33,13 @@ program
     parsePlatforms,
     ["ios", "android"],
   )
+  .option(
+    "--setup <setup>",
+    "Capacitor setup profile: minimal or recommended",
+    parseSetup,
+  )
+  .option("--safe-area", "add global top and bottom safe area padding")
+  .option("--no-safe-area", "do not add global safe area padding")
   .option("--skip-install", "do not install Capacitor packages")
   .option("--skip-build", "do not build the web application")
   .option("--skip-native", "do not add or synchronize native projects")
@@ -42,6 +53,8 @@ program
       dryRun: commandOptions.dryRun ?? false,
       framework: commandOptions.framework,
       platforms: commandOptions.platforms,
+      safeArea: commandOptions.safeArea,
+      setup: commandOptions.setup,
       skipBuild: commandOptions.skipBuild ?? false,
       skipInstall: commandOptions.skipInstall ?? false,
       skipNative: commandOptions.skipNative ?? false,
@@ -79,4 +92,13 @@ function parsePlatforms(value: string): Platform[] {
   }
 
   return [...new Set(platforms)] as Platform[];
+}
+
+function parseSetup(value: string): SetupProfile {
+  if (value === "minimal" || value === "recommended") {
+    return value;
+  }
+  throw new InvalidArgumentError(
+    'Setup must be "minimal" or "recommended".',
+  );
 }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { detectAdapters } from "../adapters/index.js";
 import { configureCapacitor } from "../capacitor/configure.js";
 import {
@@ -15,15 +16,20 @@ import {
   getProjectName,
   loadProject,
 } from "../core/project.js";
+import { configureSafeArea } from "../core/safe-area.js";
+import { chooseSafeArea } from "../core/safe-area-selection.js";
+import { chooseSetup } from "../core/setup-selection.js";
 import type {
   ConfigureResult,
   Disclaimer,
   FrameworkAdapter,
   InitOptions,
+  SetupProfile,
 } from "../core/types.js";
 
 export async function initCommand(options: InitOptions): Promise<void> {
   const project = await loadProject(options.directory);
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
   logger.heading("Capstart");
   const detected = detectAdapters(project);
@@ -32,9 +38,18 @@ export async function initCommand(options: InitOptions): Promise<void> {
   const adapter = await chooseAdapter({
     acceptDetected: options.yes,
     detected,
-    interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    interactive,
     requested: options.framework,
   });
+  const setup = await chooseSetup({
+    interactive,
+    requested: options.setup,
+  });
+  const safeArea = await chooseSafeArea({
+    interactive,
+    requested: options.safeArea,
+  });
+  const webDir = await adapter.resolveWebDir(project);
 
   if (!detected.includes(adapter)) {
     logger.warning(`${adapter.label} was selected but was not automatically detected.`);
@@ -49,6 +64,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
   if (errors.length > 0) {
     throw new Error(errors.map((error) => error.message).join("\n"));
   }
+  const safeAreaResult = safeArea
+    ? await configureSafeArea(project, adapter.id, true)
+    : undefined;
 
   const appId = options.appId ?? createDefaultAppId(project);
   const appName = options.appName ?? getProjectName(project);
@@ -61,12 +79,22 @@ export async function initCommand(options: InitOptions): Promise<void> {
       appName,
       dryRun: true,
       platforms: options.platforms,
-      webDir: adapter.webDir,
+      safeArea,
+      setup,
+      webDir,
     });
-
     logger.heading("Planned changes");
     logger.info(`Configure ${adapter.label} for Capacitor`);
-    logger.info(`Configure Capacitor with webDir "${adapter.webDir}"`);
+    logger.info(`Configure Capacitor with webDir "${webDir}"`);
+    if (setup === "recommended") {
+      logger.info("Install recommended Capacitor base plugins");
+      logger.info("Configure recommended Capacitor plugin defaults");
+    }
+    if (safeAreaResult) {
+      logger.info(
+        `Add top and bottom safe area padding to ${path.relative(project.root, safeAreaResult.cssPath)}`,
+      );
+    }
     logger.success("Dry run complete. No files were changed.");
     printFinalGuidance(frameworkResult.disclaimers);
     return;
@@ -78,10 +106,17 @@ export async function initCommand(options: InitOptions): Promise<void> {
     appName,
     options,
     project,
+    safeArea,
+    setup,
+    webDir,
   });
 
   logger.heading("Ready");
-  logger.success("Your base Capacitor setup is ready.");
+  logger.success(
+    setup === "recommended"
+      ? "Your recommended Capacitor setup is ready."
+      : "Your base Capacitor setup is ready.",
+  );
 
   logger.heading("Scripts added");
   logger.command(
@@ -103,7 +138,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   logger.heading("Next steps");
   logger.info(
-    "Review recommended plugins, native configuration, and production setup:",
+    setup === "recommended"
+      ? "Review native configuration and production setup:"
+      : "Review recommended plugins, native configuration, and production setup:",
   );
   logger.link(
     "https://capstart.dev/docs/installation/#3-add-recommended-capacitor-base-plugins",
@@ -111,7 +148,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
 
   await offerGithubStar({
     cwd: project.root,
-    interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    interactive,
   });
 
   printFinalGuidance(frameworkResult.disclaimers);
@@ -123,8 +160,12 @@ async function runSetup(context: {
   appName: string;
   options: InitOptions;
   project: Awaited<ReturnType<typeof loadProject>>;
+  safeArea: boolean;
+  setup: SetupProfile;
+  webDir: string;
 }): Promise<ConfigureResult> {
-  const { adapter, appId, appName, options, project } = context;
+  const { adapter, appId, appName, options, project, safeArea, setup, webDir } =
+    context;
   const progress = createProgress(Boolean(process.stdout.isTTY));
 
   const frameworkResult = await runStep(
@@ -139,13 +180,21 @@ async function runSetup(context: {
       appName,
       dryRun: false,
       platforms: options.platforms,
-      webDir: adapter.webDir,
+      safeArea,
+      setup,
+      webDir,
     }),
   );
 
+  if (safeArea) {
+    await runStep(progress, "Configure safe area insets", () =>
+      configureSafeArea(project, adapter.id, false),
+    );
+  }
+
   if (!options.skipInstall) {
-    await runStep(progress, "Install Capacitor packages", () =>
-      installCapacitor(project, options.platforms),
+    await runStep(progress, `Install Capacitor packages (${setup})`, () =>
+      installCapacitor(project, options.platforms, setup),
     );
   }
   if (!options.skipBuild) {

--- a/cli/src/core/safe-area-selection.ts
+++ b/cli/src/core/safe-area-selection.ts
@@ -1,0 +1,44 @@
+import {
+  cancel,
+  confirm,
+  isCancel,
+} from "@clack/prompts";
+
+export interface SafeAreaPrompts {
+  confirmSafeArea(): Promise<boolean>;
+}
+
+export const terminalSafeAreaPrompts: SafeAreaPrompts = {
+  async confirmSafeArea() {
+    const answer = await confirm({
+      message:
+        "Add safe area padding? (avoids clock and system UI overlaps)",
+      initialValue: true,
+    });
+    return unwrapPrompt(answer);
+  },
+};
+
+export async function chooseSafeArea(options: {
+  interactive: boolean;
+  prompts?: SafeAreaPrompts;
+  requested?: boolean;
+}): Promise<boolean> {
+  if (options.requested !== undefined) {
+    return options.requested;
+  }
+
+  if (!options.interactive) {
+    return false;
+  }
+
+  return (options.prompts ?? terminalSafeAreaPrompts).confirmSafeArea();
+}
+
+function unwrapPrompt<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Capstart initialization cancelled.");
+    throw new Error("Initialization cancelled.");
+  }
+  return value;
+}

--- a/cli/src/core/safe-area.ts
+++ b/cli/src/core/safe-area.ts
@@ -1,0 +1,225 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { Node, SyntaxKind, VariableDeclarationKind } from "ts-morph";
+import { findConfigFile, loadSourceFile, setObjectProperty } from "./ast.js";
+import { pathExists } from "./project.js";
+import type {
+  FrameworkId,
+  ProjectContext,
+} from "./types.js";
+
+const safeAreaMarker = "/* Capstart safe area insets */";
+const safeAreaCss = [
+  safeAreaMarker,
+  "html {",
+  "  padding-top: var(--safe-area-inset-top, env(safe-area-inset-top, 0px));",
+  "  padding-bottom: var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px));",
+  "}",
+  "",
+].join("\n");
+
+const globalCssCandidates: Record<FrameworkId, string[]> = {
+  nextjs: [
+    "src/app/globals.css",
+    "app/globals.css",
+    "src/styles/globals.css",
+    "styles/globals.css",
+    "src/index.css",
+    "src/app.css",
+  ],
+  "tanstack-start": [
+    "src/styles.css",
+    "src/index.css",
+    "src/app.css",
+    "src/globals.css",
+    "src/styles/globals.css",
+  ],
+};
+
+export async function configureSafeArea(
+  project: ProjectContext,
+  framework: FrameworkId,
+  dryRun: boolean,
+): Promise<{ cssPath: string }> {
+  const cssPath = await findConfigFile(
+    project.root,
+    globalCssCandidates[framework],
+  );
+  if (!cssPath) {
+    throw new Error(
+      "Could not find a global CSS file for safe area padding. Add it manually or run Capstart with --no-safe-area.",
+    );
+  }
+
+  const viewportTarget = await findViewportTarget(project.root, framework);
+  if (!viewportTarget) {
+    throw new Error(
+      "Could not find where to add viewport-fit=cover. Add it manually or run Capstart with --no-safe-area.",
+    );
+  }
+
+  if (!dryRun) {
+    await addSafeAreaCss(cssPath);
+    await viewportTarget.configure();
+  }
+
+  return { cssPath };
+}
+
+async function addSafeAreaCss(cssPath: string): Promise<void> {
+  const css = await readFile(cssPath, "utf8");
+  if (
+    css.includes(safeAreaMarker) ||
+    (css.includes("--safe-area-inset-top") &&
+      css.includes("--safe-area-inset-bottom"))
+  ) {
+    return;
+  }
+
+  await writeFile(
+    cssPath,
+    `${css.trimEnd()}\n\n${safeAreaCss}`,
+  );
+}
+
+async function findViewportTarget(
+  root: string,
+  framework: FrameworkId,
+): Promise<{ configure(): Promise<void> } | undefined> {
+  if (framework === "tanstack-start") {
+    const rootRoutePath = await findConfigFile(root, [
+      "src/routes/__root.tsx",
+      "src/routes/__root.ts",
+    ]);
+    return rootRoutePath ? sourceViewportTarget(rootRoutePath) : undefined;
+  }
+
+  const layoutPath = await findConfigFile(root, [
+    "src/app/layout.tsx",
+    "app/layout.tsx",
+    "src/app/layout.ts",
+    "app/layout.ts",
+  ]);
+  if (layoutPath) {
+    return nextLayoutViewportTarget(layoutPath);
+  }
+
+  const documentPath = await findConfigFile(root, [
+    "src/pages/_document.tsx",
+    "pages/_document.tsx",
+    "src/pages/_document.ts",
+    "pages/_document.ts",
+  ]);
+  if (documentPath) {
+    return markupViewportTarget(documentPath);
+  }
+
+  const indexPath = path.join(root, "index.html");
+  if (await pathExists(indexPath)) {
+    return markupViewportTarget(indexPath);
+  }
+
+  return undefined;
+}
+
+function sourceViewportTarget(
+  sourcePath: string,
+): { configure(): Promise<void> } | undefined {
+  const sourceFile = loadSourceFile(sourcePath);
+  const viewportContent = sourceFile
+    .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+    .find((property) => {
+      if (property.getName() !== "content") {
+        return false;
+      }
+      const parent = property.getParent();
+      if (!Node.isObjectLiteralExpression(parent)) {
+        return false;
+      }
+      const nameProperty = parent.getProperty("name");
+      if (!Node.isPropertyAssignment(nameProperty)) {
+        return false;
+      }
+      return nameProperty.getInitializer()?.getText().replaceAll(/['"]/g, "") ===
+        "viewport";
+    });
+
+  if (!viewportContent) {
+    return undefined;
+  }
+  const initializer = viewportContent.getInitializer();
+  if (!Node.isStringLiteral(initializer)) {
+    return undefined;
+  }
+
+  return {
+    async configure() {
+      const value = initializer.getLiteralValue();
+      if (!value.includes("viewport-fit=cover")) {
+        initializer.setLiteralValue(`${value}, viewport-fit=cover`);
+        await sourceFile.save();
+      }
+    },
+  };
+}
+
+function nextLayoutViewportTarget(
+  layoutPath: string,
+): { configure(): Promise<void> } | undefined {
+  const sourceFile = loadSourceFile(layoutPath);
+  if (sourceFile.getFunction("generateViewport")) {
+    return undefined;
+  }
+
+  const viewport = sourceFile.getVariableDeclaration("viewport");
+  if (viewport) {
+    const initializer = viewport.getInitializer();
+    if (!Node.isObjectLiteralExpression(initializer)) {
+      return undefined;
+    }
+    return {
+      async configure() {
+        setObjectProperty(initializer, "viewportFit", '"cover"');
+        await sourceFile.save();
+      },
+    };
+  }
+
+  return {
+    async configure() {
+      sourceFile.addVariableStatement({
+        declarationKind: VariableDeclarationKind.Const,
+        declarations: [
+          {
+            name: "viewport",
+            initializer: '{ viewportFit: "cover" }',
+          },
+        ],
+        isExported: true,
+      });
+      await sourceFile.save();
+    },
+  };
+}
+
+function markupViewportTarget(
+  markupPath: string,
+): { configure(): Promise<void> } {
+  return {
+    async configure() {
+      const markup = await readFile(markupPath, "utf8");
+      if (markup.includes("viewport-fit=cover")) {
+        return;
+      }
+
+      const updated = markup.replace(
+        /(<meta\s+[^>]*name=["']viewport["'][^>]*content=["'])([^"']*)(["'][^>]*>)/i,
+        "$1$2, viewport-fit=cover$3",
+      );
+      if (updated === markup) {
+        throw new Error(`Could not safely update ${path.basename(markupPath)}.`);
+      }
+      await writeFile(markupPath, updated);
+    },
+  };
+}

--- a/cli/src/core/setup-selection.ts
+++ b/cli/src/core/setup-selection.ts
@@ -1,0 +1,56 @@
+import {
+  cancel,
+  isCancel,
+  select,
+} from "@clack/prompts";
+import type { SetupProfile } from "./types.js";
+
+export interface SetupPrompts {
+  selectSetup(): Promise<SetupProfile>;
+}
+
+export const terminalSetupPrompts: SetupPrompts = {
+  async selectSetup() {
+    const answer = await select({
+      message: "Which Capacitor setup should Capstart install?",
+      initialValue: "recommended",
+      options: [
+        {
+          value: "minimal",
+          label: "Minimal",
+          hint: "Capacitor core and selected native platforms",
+        },
+        {
+          value: "recommended",
+          label: "Recommended",
+          hint: "Minimal plus common mobile behavior plugins",
+        },
+      ],
+    });
+    return unwrapPrompt(answer) as SetupProfile;
+  },
+};
+
+export async function chooseSetup(options: {
+  interactive: boolean;
+  prompts?: SetupPrompts;
+  requested?: SetupProfile;
+}): Promise<SetupProfile> {
+  if (options.requested) {
+    return options.requested;
+  }
+
+  if (!options.interactive) {
+    return "minimal";
+  }
+
+  return (options.prompts ?? terminalSetupPrompts).selectSetup();
+}
+
+function unwrapPrompt<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    cancel("Capstart initialization cancelled.");
+    throw new Error("Initialization cancelled.");
+  }
+  return value;
+}

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -1,6 +1,7 @@
 export type FrameworkId = "nextjs" | "tanstack-start";
 export type Platform = "ios" | "android";
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+export type SetupProfile = "minimal" | "recommended";
 
 export interface PackageJson {
   name?: string;
@@ -34,10 +35,10 @@ export interface Disclaimer {
 export interface FrameworkAdapter {
   id: FrameworkId;
   label: string;
-  webDir: string;
   detect(project: ProjectContext): boolean;
   validate(project: ProjectContext): Promise<Diagnostic[]>;
   configure(project: ProjectContext, dryRun: boolean): Promise<ConfigureResult>;
+  resolveWebDir(project: ProjectContext): Promise<string> | string;
 }
 
 export interface InitOptions {
@@ -48,6 +49,8 @@ export interface InitOptions {
   framework?: FrameworkId;
   yes: boolean;
   platforms: Platform[];
+  safeArea?: boolean;
+  setup?: SetupProfile;
   skipBuild: boolean;
   skipInstall: boolean;
   skipNative: boolean;

--- a/cli/test/adapters.test.ts
+++ b/cli/test/adapters.test.ts
@@ -33,6 +33,7 @@ test("configures a standard Next.js project", async () => {
   const result = await nextjsAdapter.configure(project, false);
   const config = await readFile(configPath, "utf8");
 
+  assert.equal(await nextjsAdapter.resolveWebDir(project), "out");
   assert.match(config, /output: "export"/);
   assert.match(config, /trailingSlash: true/);
   assert.match(config, /unoptimized: true/);
@@ -71,12 +72,42 @@ test("configures TanStack Start SPA mode without removing prerender options", as
   const result = await tanstackStartAdapter.configure(project, false);
   const config = await readFile(configPath, "utf8");
 
+  assert.equal(await tanstackStartAdapter.resolveWebDir(project), "dist/client");
   assert.match(config, /spa: \{/);
   assert.match(config, /enabled: true/);
   assert.match(config, /outputPath: "\/index\.html"/);
   assert.match(config, /prerender: \{ enabled: true \}/);
   assert.match(result.disclaimers[0].title, /do not run inside the Capacitor app/);
   assert.match(result.disclaimers[0].details.join(" "), /reachable from the device/);
+});
+
+test("uses the Nitro public output for TanStack Start", async () => {
+  const root = await createProject({
+    dependencies: {
+      "@tanstack/react-start": "^1.0.0",
+      nitro: "latest",
+    },
+    scripts: { build: "vite build" },
+  });
+  await writeFile(
+    path.join(root, "vite.config.ts"),
+    [
+      'import { tanstackStart } from "@tanstack/react-start/plugin/vite";',
+      'import { nitro as nitroPlugin } from "nitro/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [nitroPlugin(), tanstackStart()],",
+      "});",
+      "",
+    ].join("\n"),
+  );
+  const project = await loadProject(root);
+
+  assert.equal(
+    await tanstackStartAdapter.resolveWebDir(project),
+    ".output/public",
+  );
 });
 
 test("dry-run does not write framework configuration", async () => {
@@ -106,6 +137,8 @@ test("creates Capacitor config and package scripts", async () => {
     appName: "Example",
     dryRun: false,
     platforms: ["ios", "android"],
+    safeArea: false,
+    setup: "minimal",
     webDir: "out",
   });
 
@@ -116,6 +149,8 @@ test("creates Capacitor config and package scripts", async () => {
 
   assert.match(config, /appId: "com\.example\.app"/);
   assert.match(config, /webDir: "out"/);
+  assert.doesNotMatch(config, /KeyboardResize/);
+  assert.doesNotMatch(config, /plugins:/);
   assert.equal(
     packageJson.scripts["cap:sync"],
     "npm run build && npm exec cap -- sync",
@@ -124,6 +159,141 @@ test("creates Capacitor config and package scripts", async () => {
     packageJson.scripts["cap:ios"],
     "npm run cap:sync && npm exec cap -- open ios",
   );
+});
+
+test("creates recommended Capacitor plugin configuration", async () => {
+  const root = await createProject({
+    dependencies: { next: "^16.0.0" },
+    scripts: { build: "next build" },
+  });
+  const project = await loadProject(root);
+
+  await configureCapacitor(project, {
+    appId: "com.example.app",
+    appName: "Example",
+    dryRun: false,
+    platforms: ["ios"],
+    safeArea: false,
+    setup: "recommended",
+    webDir: "out",
+  });
+
+  const config = await readFile(path.join(root, "capacitor.config.ts"), "utf8");
+
+  assert.match(
+    config,
+    /import \{ KeyboardResize, KeyboardStyle \} from "@capacitor\/keyboard";/,
+  );
+  assert.match(config, /import \{ Style \} from "@capacitor\/status-bar";/);
+  assert.match(config, /resize: KeyboardResize\.Native/);
+  assert.match(config, /style: KeyboardStyle\.Default/);
+  assert.match(config, /launchShowDuration: 500/);
+  assert.match(config, /launchFadeOutDuration: 200/);
+  assert.match(config, /overlaysWebView: false/);
+  assert.match(config, /style: Style\.Default/);
+});
+
+test("merges recommended plugin defaults into an existing Capacitor config", async () => {
+  const root = await createProject({
+    dependencies: { next: "^16.0.0" },
+    scripts: { build: "next build" },
+  });
+  const configPath = path.join(root, "capacitor.config.ts");
+  await writeFile(
+    configPath,
+    [
+      'import type { CapacitorConfig } from "@capacitor/cli";',
+      "",
+      "const config: CapacitorConfig = {",
+      '  webDir: "dist",',
+      "  plugins: {",
+      "    CustomPlugin: { enabled: true },",
+      "    Keyboard: { customSetting: true, resizeOnFullScreen: false },",
+      "  },",
+      "};",
+      "",
+      "export default config;",
+      "",
+    ].join("\n"),
+  );
+  const project = await loadProject(root);
+
+  await configureCapacitor(project, {
+    appId: "com.example.app",
+    appName: "Example",
+    dryRun: false,
+    platforms: ["ios", "android"],
+    safeArea: false,
+    setup: "recommended",
+    webDir: "out",
+  });
+  await configureCapacitor(project, {
+    appId: "com.example.app",
+    appName: "Example",
+    dryRun: false,
+    platforms: ["ios", "android"],
+    safeArea: false,
+    setup: "recommended",
+    webDir: "out",
+  });
+
+  const config = await readFile(configPath, "utf8");
+
+  assert.match(config, /CustomPlugin: \{ enabled: true \}/);
+  assert.match(config, /customSetting: true/);
+  assert.match(config, /resizeOnFullScreen: true/);
+  assert.match(config, /SplashScreen: \{/);
+  assert.match(config, /StatusBar: \{/);
+  assert.equal(
+    config.match(/from "@capacitor\/keyboard"/g)?.length,
+    1,
+  );
+});
+
+test("merges serialized recommended defaults into a JSON Capacitor config", async () => {
+  const root = await createProject({
+    dependencies: { next: "^16.0.0" },
+    scripts: { build: "next build" },
+  });
+  const configPath = path.join(root, "capacitor.config.json");
+  await writeFile(
+    configPath,
+    `${JSON.stringify(
+      {
+        plugins: {
+          CustomPlugin: { enabled: true },
+          Keyboard: { customSetting: true },
+        },
+        webDir: "dist",
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const project = await loadProject(root);
+
+  await configureCapacitor(project, {
+    appId: "com.example.app",
+    appName: "Example",
+    dryRun: false,
+    platforms: ["android"],
+    safeArea: false,
+    setup: "recommended",
+    webDir: "out",
+  });
+
+  const config = JSON.parse(await readFile(configPath, "utf8")) as {
+    plugins: Record<string, Record<string, unknown>>;
+    webDir: string;
+  };
+
+  assert.equal(config.webDir, "out");
+  assert.equal(config.plugins.CustomPlugin.enabled, true);
+  assert.equal(config.plugins.Keyboard.customSetting, true);
+  assert.equal(config.plugins.Keyboard.resize, "native");
+  assert.equal(config.plugins.Keyboard.style, "DEFAULT");
+  assert.equal(config.plugins.SplashScreen.launchShowDuration, 500);
+  assert.equal(config.plugins.StatusBar.style, "DEFAULT");
 });
 
 async function createProject(packageJson: Record<string, unknown>) {

--- a/cli/test/capacitor-install.test.ts
+++ b/cli/test/capacitor-install.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getCapacitorRuntimePackages,
+  recommendedCapacitorPlugins,
+} from "../src/capacitor/install.js";
+
+test("minimal setup only includes Capacitor core and platforms", () => {
+  assert.deepEqual(
+    getCapacitorRuntimePackages(["ios", "android"], "minimal"),
+    ["@capacitor/core", "@capacitor/ios", "@capacitor/android"],
+  );
+});
+
+test("recommended setup includes the baseline Capacitor plugins", () => {
+  assert.deepEqual(
+    getCapacitorRuntimePackages(["ios"], "recommended"),
+    ["@capacitor/core", "@capacitor/ios", ...recommendedCapacitorPlugins],
+  );
+  assert.deepEqual(recommendedCapacitorPlugins, [
+    "@capacitor/keyboard",
+    "@capacitor/network",
+    "@capacitor/device",
+    "@capacitor/splash-screen",
+    "@capacitor/status-bar",
+  ]);
+});

--- a/cli/test/init-output.test.ts
+++ b/cli/test/init-output.test.ts
@@ -74,6 +74,49 @@ test("prints a concise final flow with the disclaimer last", async () => {
   );
 });
 
+test("prints recommended setup guidance when requested", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-output-test-"));
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-app",
+        dependencies: { next: "^16.0.0" },
+        scripts: { build: "next build" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const output: string[] = [];
+  const originalLog = console.log;
+  console.log = (...values: unknown[]) => {
+    output.push(values.map(String).join(" "));
+  };
+
+  try {
+    await initCommand({
+      directory: root,
+      dryRun: false,
+      framework: "nextjs",
+      platforms: ["ios"],
+      setup: "recommended",
+      skipBuild: true,
+      skipInstall: true,
+      skipNative: true,
+      yes: false,
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const text = stripAnsi(output.join("\n"));
+  assert.match(text, /Your recommended Capacitor setup is ready\./);
+  assert.match(text, /Review native configuration and production setup:/);
+  assert.doesNotMatch(text, /Review recommended plugins/);
+});
+
 function stripAnsi(value: string): string {
   return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
 }

--- a/cli/test/safe-area-selection.test.ts
+++ b/cli/test/safe-area-selection.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  chooseSafeArea,
+  type SafeAreaPrompts,
+} from "../src/core/safe-area-selection.js";
+
+test("uses an explicitly requested safe area choice", async () => {
+  assert.equal(
+    await chooseSafeArea({
+      interactive: false,
+      requested: true,
+    }),
+    true,
+  );
+});
+
+test("does not add safe area padding outside an interactive terminal by default", async () => {
+  assert.equal(await chooseSafeArea({ interactive: false }), false);
+});
+
+test("asks about safe area padding in an interactive terminal", async () => {
+  let promptCalls = 0;
+  const prompts: SafeAreaPrompts = {
+    async confirmSafeArea() {
+      promptCalls += 1;
+      return true;
+    },
+  };
+
+  assert.equal(
+    await chooseSafeArea({
+      interactive: true,
+      prompts,
+    }),
+    true,
+  );
+  assert.equal(promptCalls, 1);
+});

--- a/cli/test/safe-area.test.ts
+++ b/cli/test/safe-area.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { configureCapacitor } from "../src/capacitor/configure.js";
+import { configureSafeArea } from "../src/core/safe-area.js";
+import { loadProject } from "../src/core/project.js";
+
+test("adds Capacitor 8 safe area variables and viewport fit to TanStack Start", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/styles.css");
+  const rootRoutePath = path.join(root, "src/routes/__root.tsx");
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    rootRoutePath,
+    [
+      "const head = {",
+      "  meta: [",
+      "    { name: 'viewport', content: 'width=device-width, initial-scale=1' },",
+      "  ],",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "tanstack-start", false);
+  await configureSafeArea(project, "tanstack-start", false);
+
+  const css = await readFile(cssPath, "utf8");
+  const rootRoute = await readFile(rootRoutePath, "utf8");
+
+  assert.equal(css.match(/Capstart safe area insets/g)?.length, 1);
+  assert.match(
+    css,
+    /padding-top: var\(--safe-area-inset-top, env\(safe-area-inset-top, 0px\)\)/,
+  );
+  assert.match(
+    css,
+    /padding-bottom: var\(--safe-area-inset-bottom, env\(safe-area-inset-bottom, 0px\)\)/,
+  );
+  assert.match(rootRoute, /viewport-fit=cover/);
+});
+
+test("adds viewportFit to a Next.js app layout", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "app/globals.css");
+  const layoutPath = path.join(root, "app/layout.tsx");
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    layoutPath,
+    "export default function Layout() { return null; }\n",
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "nextjs", false);
+
+  const layout = await readFile(layoutPath, "utf8");
+  assert.match(layout, /export const viewport = \{ viewportFit: "cover" \}/);
+});
+
+test("adds viewport fit to a Next.js pages document", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/styles/globals.css");
+  const documentPath = path.join(root, "src/pages/_document.tsx");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await mkdir(path.dirname(documentPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    documentPath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "nextjs", false);
+
+  assert.match(await readFile(documentPath, "utf8"), /viewport-fit=cover/);
+});
+
+test("adds SystemBars CSS inset handling to Capacitor config", async () => {
+  const root = await createProject();
+  const project = await loadProject(root);
+
+  await configureCapacitor(project, {
+    appId: "com.example.app",
+    appName: "Example",
+    dryRun: false,
+    platforms: ["ios", "android"],
+    safeArea: true,
+    setup: "recommended",
+    webDir: "dist",
+  });
+
+  const config = await readFile(path.join(root, "capacitor.config.ts"), "utf8");
+  assert.match(config, /SystemBars: \{/);
+  assert.match(config, /insetsHandling: "css"/);
+  assert.match(config, /Keyboard: \{/);
+});
+
+async function createProject() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-safe-area-test-"));
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-app",
+        scripts: { build: "vite build" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await Promise.all([
+    mkdir(path.join(root, "src/routes"), { recursive: true }),
+    mkdir(path.join(root, "app"), { recursive: true }),
+  ]);
+  return root;
+}

--- a/cli/test/setup-selection.test.ts
+++ b/cli/test/setup-selection.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  chooseSetup,
+  type SetupPrompts,
+} from "../src/core/setup-selection.js";
+
+test("uses an explicitly requested setup", async () => {
+  const setup = await chooseSetup({
+    interactive: false,
+    requested: "recommended",
+  });
+
+  assert.equal(setup, "recommended");
+});
+
+test("keeps the minimal setup outside an interactive terminal", async () => {
+  const setup = await chooseSetup({
+    interactive: false,
+  });
+
+  assert.equal(setup, "minimal");
+});
+
+test("asks for a setup in an interactive terminal", async () => {
+  let promptCalls = 0;
+  const prompts: SetupPrompts = {
+    async selectSetup() {
+      promptCalls += 1;
+      return "recommended";
+    },
+  };
+
+  const setup = await chooseSetup({
+    interactive: true,
+    prompts,
+  });
+
+  assert.equal(setup, "recommended");
+  assert.equal(promptCalls, 1);
+});


### PR DESCRIPTION
## Summary

- add interactive and flag-driven `minimal` / `recommended` Capacitor setup profiles
- install and configure the baseline Capacitor plugins in recommended mode
- optionally configure Capacitor 8 safe-area CSS variables, viewport metadata, and `SystemBars.insetsHandling`
- resolve TanStack Start Nitro builds to `.output/public` while preserving `dist/client` for the standard adapter
- bump the CLI package to `0.2.0`

## Why

Mobile projects commonly need the same baseline native plugins and safe-area handling immediately after Capacitor initialization. TanStack Start projects using Nitro also build their public assets outside the previously assumed `dist/client` directory, which caused `cap sync` to fail.

## Impact

Interactive users can choose the recommended setup and safe-area handling during initialization. Non-interactive behavior remains minimal by default and can be controlled with `--setup`, `--safe-area`, and `--no-safe-area`.

## Validation

- `bun run typecheck`
- `bun test` (36 passed)
- `bun run build`
- `bun publish --dry-run`
- `git diff --check`