### PR TITLE
[codex] Add Nuxt and Vue CLI support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Capstart CLI
 
-Add Capacitor to an existing Next.js or TanStack Start application.
+Add Capacitor to an existing Next.js, Nuxt, TanStack Start, or Vue application.
 
 ```bash
 npx capstart init ..
@@ -45,14 +45,18 @@ changes the project:
 ? Use the detected framework Next.js? Yes
 ```
 
-If the detection is refused, Capstart lets you choose between Next.js and
-TanStack Start.
+If the detection is refused, Capstart lets you choose between Next.js, Nuxt,
+TanStack Start, and Vue.
 
 ## Supported frameworks
 
 - Next.js projects that can use static export
+- Nuxt projects that can use client-only rendering. Capstart switches the build
+  script to `nuxt generate` and uses `.output/public`.
 - TanStack Start projects that can use SPA mode. Capstart uses `.output/public`
   when the Vite config includes Nitro, and `dist/client` otherwise.
+- Standalone Vue projects built with Vite or Vue CLI. Capstart uses `dist` by
+  default and detects static custom `build.outDir` or `outputDir` values.
 
 Server-only features must remain hosted remotely and be called from the mobile
 application over HTTP.
@@ -70,14 +74,16 @@ npx capstart init .
 npx capstart init ../my-app --app-id com.example.myapp
 npx capstart init . --platforms ios
 npx capstart init . --setup recommended
+npx capstart init . --framework nuxt --dry-run
 npx capstart init . --framework tanstack-start --dry-run
+npx capstart init . --framework vue --dry-run
 npx capstart init . --yes
 ```
 
 Useful options:
 
 ```text
---framework <nextjs|tanstack-start>
+--framework <nextjs|nuxt|tanstack-start|vue>
 --app-id <id>
 --app-name <name>
 --platforms <ios,android>

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,9 @@
     "cli",
     "mobile",
     "nextjs",
-    "tanstack-start"
+    "nuxt",
+    "tanstack-start",
+    "vue"
   ],
   "repository": {
     "type": "git",

--- a/cli/src/adapters/index.ts
+++ b/cli/src/adapters/index.ts
@@ -4,9 +4,16 @@ import type {
   ProjectContext,
 } from "../core/types.js";
 import { nextjsAdapter } from "./nextjs.js";
+import { nuxtAdapter } from "./nuxt.js";
 import { tanstackStartAdapter } from "./tanstack-start.js";
+import { vueAdapter } from "./vue.js";
 
-const adapters: FrameworkAdapter[] = [nextjsAdapter, tanstackStartAdapter];
+const adapters: FrameworkAdapter[] = [
+  nextjsAdapter,
+  nuxtAdapter,
+  tanstackStartAdapter,
+  vueAdapter,
+];
 
 export function getAdapter(id: FrameworkId): FrameworkAdapter {
   const adapter = adapters.find((candidate) => candidate.id === id);

--- a/cli/src/adapters/nuxt.ts
+++ b/cli/src/adapters/nuxt.ts
@@ -1,0 +1,104 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  findConfigFile,
+  findExportedObject,
+  loadSourceFile,
+  setObjectProperty,
+} from "../core/ast.js";
+import {
+  hasDependency,
+  savePackageJson,
+} from "../core/project.js";
+import type { FrameworkAdapter } from "../core/types.js";
+
+const configNames = [
+  "nuxt.config.ts",
+  "nuxt.config.mts",
+  "nuxt.config.mjs",
+  "nuxt.config.js",
+  "nuxt.config.cjs",
+];
+
+export const nuxtAdapter: FrameworkAdapter = {
+  id: "nuxt",
+  label: "Nuxt",
+
+  detect(project) {
+    return hasDependency(project, "nuxt");
+  },
+
+  resolveWebDir() {
+    return ".output/public";
+  },
+
+  async validate(project) {
+    const diagnostics = [];
+    if (!project.packageJson.scripts?.build) {
+      diagnostics.push({
+        level: "error" as const,
+        message: 'Missing a "build" script in package.json.',
+      });
+    }
+
+    const configPath = await findConfigFile(project.root, configNames);
+    if (configPath) {
+      const sourceFile = loadSourceFile(configPath);
+      if (!findExportedObject(sourceFile, ["defineNuxtConfig"])) {
+        diagnostics.push({
+          level: "error" as const,
+          message:
+            "The existing Nuxt config is too dynamic to update safely. Export a defineNuxtConfig() object before running Capstart.",
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+
+  async configure(project, dryRun) {
+    const disclaimers = [
+      {
+        title: "Nuxt server features do not run inside the Capacitor app.",
+        details: [
+          "Move server routes, server middleware, and Nitro handlers to a deployed backend.",
+          "Runtime SSR, hybrid rendering, and server route rules are disabled by the client-only build.",
+          "Configure the mobile app to call an HTTPS API URL that is reachable from the device.",
+          'Do not use "localhost" for the backend URL: on a phone or emulator, it points to the device itself.',
+        ],
+      },
+    ];
+    const configPath = await findConfigFile(project.root, configNames);
+
+    if (!configPath) {
+      if (!dryRun) {
+        await writeFile(
+          path.join(project.root, "nuxt.config.ts"),
+          [
+            "export default defineNuxtConfig({",
+            "  ssr: false,",
+            "});",
+            "",
+          ].join("\n"),
+        );
+      }
+    } else {
+      const sourceFile = loadSourceFile(configPath);
+      const config = findExportedObject(sourceFile, ["defineNuxtConfig"]);
+      if (!config) {
+        throw new Error("Could not safely update the existing Nuxt config.");
+      }
+
+      setObjectProperty(config, "ssr", "false");
+      if (!dryRun) {
+        await sourceFile.save();
+      }
+    }
+
+    project.packageJson.scripts ??= {};
+    project.packageJson.scripts.build = "nuxt generate";
+    await savePackageJson(project, dryRun);
+
+    return { disclaimers };
+  },
+};

--- a/cli/src/adapters/vue.ts
+++ b/cli/src/adapters/vue.ts
@@ -1,0 +1,115 @@
+import { Node, type ObjectLiteralExpression } from "ts-morph";
+import {
+  findConfigFile,
+  findExportedObject,
+  loadSourceFile,
+} from "../core/ast.js";
+import { hasDependency } from "../core/project.js";
+import type { FrameworkAdapter } from "../core/types.js";
+
+const viteConfigNames = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.mjs",
+  "vite.config.js",
+  "vite.config.cjs",
+];
+const vueCliConfigNames = [
+  "vue.config.ts",
+  "vue.config.mts",
+  "vue.config.mjs",
+  "vue.config.js",
+  "vue.config.cjs",
+];
+
+export const vueAdapter: FrameworkAdapter = {
+  id: "vue",
+  label: "Vue",
+
+  detect(project) {
+    return (
+      hasDependency(project, "vue") &&
+      !hasDependency(project, "nuxt") &&
+      (hasDependency(project, "vite") ||
+        hasDependency(project, "@vue/cli-service"))
+    );
+  },
+
+  async resolveWebDir(project) {
+    const viteConfigPath = await findConfigFile(project.root, viteConfigNames);
+    if (viteConfigPath) {
+      const config = findExportedObject(loadSourceFile(viteConfigPath), [
+        "defineConfig",
+      ]);
+      const build = config ? getObjectProperty(config, "build") : undefined;
+      const outDir = build ? getStringProperty(build, "outDir") : undefined;
+      if (outDir) {
+        return outDir;
+      }
+    }
+
+    const vueCliConfigPath = await findConfigFile(
+      project.root,
+      vueCliConfigNames,
+    );
+    if (vueCliConfigPath) {
+      const config = findExportedObject(loadSourceFile(vueCliConfigPath), [
+        "defineConfig",
+      ]);
+      const outputDir = config
+        ? getStringProperty(config, "outputDir")
+        : undefined;
+      if (outputDir) {
+        return outputDir;
+      }
+    }
+
+    return "dist";
+  },
+
+  async validate(project) {
+    if (!project.packageJson.scripts?.build) {
+      return [
+        {
+          level: "error" as const,
+          message: 'Missing a "build" script in package.json.',
+        },
+      ];
+    }
+    return [];
+  },
+
+  async configure() {
+    return { disclaimers: [] };
+  },
+};
+
+function getObjectProperty(
+  object: ObjectLiteralExpression,
+  name: string,
+): ObjectLiteralExpression | undefined {
+  const property = object.getProperty(name);
+  if (!Node.isPropertyAssignment(property)) {
+    return undefined;
+  }
+  const initializer = property.getInitializer();
+  return Node.isObjectLiteralExpression(initializer) ? initializer : undefined;
+}
+
+function getStringProperty(
+  object: ObjectLiteralExpression,
+  name: string,
+): string | undefined {
+  const property = object.getProperty(name);
+  if (!Node.isPropertyAssignment(property)) {
+    return undefined;
+  }
+  const initializer = property.getInitializer();
+  if (
+    Node.isStringLiteral(initializer) ||
+    Node.isNoSubstitutionTemplateLiteral(initializer)
+  ) {
+    return initializer.getLiteralValue();
+  }
+  return undefined;
+}

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,7 +22,7 @@ program
   .argument("[directory]", "project directory", ".")
   .option(
     "-f, --framework <framework>",
-    "framework adapter: nextjs or tanstack-start",
+    "framework adapter: nextjs, nuxt, tanstack-start, or vue",
     parseFramework,
   )
   .option("--app-id <id>", "native application id, for example com.example.app")
@@ -68,11 +68,16 @@ program.parseAsync().catch((error: unknown) => {
 });
 
 function parseFramework(value: string): FrameworkId {
-  if (value === "nextjs" || value === "tanstack-start") {
+  if (
+    value === "nextjs" ||
+    value === "nuxt" ||
+    value === "tanstack-start" ||
+    value === "vue"
+  ) {
     return value;
   }
   throw new InvalidArgumentError(
-    'Framework must be "nextjs" or "tanstack-start".',
+    'Framework must be "nextjs", "nuxt", "tanstack-start", or "vue".',
   );
 }
 

--- a/cli/src/core/ast.ts
+++ b/cli/src/core/ast.ts
@@ -31,10 +31,13 @@ export function loadSourceFile(filePath: string): SourceFile {
 
 export function findExportedObject(
   sourceFile: SourceFile,
+  wrapperNames: string[] = [],
 ): ObjectLiteralExpression | undefined {
+  const wrappers = new Set(wrapperNames);
+
   for (const exportAssignment of sourceFile.getExportAssignments()) {
     const expression = exportAssignment.getExpression();
-    const object = resolveObjectExpression(expression);
+    const object = resolveObjectExpression(expression, wrappers);
     if (object) {
       return object;
     }
@@ -44,7 +47,7 @@ export function findExportedObject(
     SyntaxKind.BinaryExpression,
   )) {
     if (binary.getLeft().getText() === "module.exports") {
-      const object = resolveObjectExpression(binary.getRight());
+      const object = resolveObjectExpression(binary.getRight(), wrappers);
       if (object) {
         return object;
       }
@@ -104,18 +107,29 @@ export function getOrCreateNestedObject(
 
 function resolveObjectExpression(
   expression: Node,
+  wrapperNames: Set<string>,
 ): ObjectLiteralExpression | undefined {
   if (Node.isObjectLiteralExpression(expression)) {
     return expression;
+  }
+
+  if (
+    Node.isCallExpression(expression) &&
+    wrapperNames.has(expression.getExpression().getText())
+  ) {
+    const argument = expression.getArguments()[0];
+    return argument
+      ? resolveObjectExpression(argument, wrapperNames)
+      : undefined;
   }
 
   if (Node.isIdentifier(expression)) {
     const declaration = expression.getDefinitions()[0]?.getDeclarationNode();
     if (Node.isVariableDeclaration(declaration)) {
       const initializer = declaration.getInitializer();
-      if (Node.isObjectLiteralExpression(initializer)) {
-        return initializer;
-      }
+      return initializer
+        ? resolveObjectExpression(initializer, wrapperNames)
+        : undefined;
     }
   }
 

--- a/cli/src/core/framework-selection.ts
+++ b/cli/src/core/framework-selection.ts
@@ -56,7 +56,7 @@ export async function chooseAdapter(options: {
     }
 
     throw new Error(
-      "Framework selection requires an interactive terminal. Pass --framework nextjs or --framework tanstack-start.",
+      "Framework selection requires an interactive terminal. Pass --framework nextjs, --framework nuxt, --framework tanstack-start, or --framework vue.",
     );
   }
 

--- a/cli/src/core/safe-area.ts
+++ b/cli/src/core/safe-area.ts
@@ -1,7 +1,13 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Node, SyntaxKind, VariableDeclarationKind } from "ts-morph";
-import { findConfigFile, loadSourceFile, setObjectProperty } from "./ast.js";
+import {
+  findConfigFile,
+  findExportedObject,
+  getOrCreateNestedObject,
+  loadSourceFile,
+  setObjectProperty,
+} from "./ast.js";
 import { pathExists } from "./project.js";
 import type {
   FrameworkId,
@@ -27,12 +33,30 @@ const globalCssCandidates: Record<FrameworkId, string[]> = {
     "src/index.css",
     "src/app.css",
   ],
+  nuxt: [
+    "app/assets/css/main.css",
+    "app/assets/css/app.css",
+    "app/assets/css/global.css",
+    "app/assets/css/tailwind.css",
+    "assets/css/main.css",
+    "assets/css/app.css",
+    "assets/css/global.css",
+    "assets/css/tailwind.css",
+  ],
   "tanstack-start": [
     "src/styles.css",
     "src/index.css",
     "src/app.css",
     "src/globals.css",
     "src/styles/globals.css",
+  ],
+  vue: [
+    "src/assets/main.css",
+    "src/assets/base.css",
+    "src/style.css",
+    "src/styles.css",
+    "src/index.css",
+    "src/app.css",
   ],
 };
 
@@ -86,12 +110,24 @@ async function findViewportTarget(
   root: string,
   framework: FrameworkId,
 ): Promise<{ configure(): Promise<void> } | undefined> {
+  if (framework === "nuxt") {
+    return nuxtViewportTarget(root);
+  }
+
   if (framework === "tanstack-start") {
     const rootRoutePath = await findConfigFile(root, [
       "src/routes/__root.tsx",
       "src/routes/__root.ts",
     ]);
     return rootRoutePath ? sourceViewportTarget(rootRoutePath) : undefined;
+  }
+
+  if (framework === "vue") {
+    const indexPath = await findConfigFile(root, [
+      "index.html",
+      "public/index.html",
+    ]);
+    return indexPath ? markupViewportTarget(indexPath) : undefined;
   }
 
   const layoutPath = await findConfigFile(root, [
@@ -120,6 +156,103 @@ async function findViewportTarget(
   }
 
   return undefined;
+}
+
+function nuxtViewportTarget(root: string): { configure(): Promise<void> } {
+  return {
+    async configure() {
+      const configPath = await findConfigFile(root, [
+        "nuxt.config.ts",
+        "nuxt.config.mts",
+        "nuxt.config.mjs",
+        "nuxt.config.js",
+        "nuxt.config.cjs",
+      ]);
+      if (!configPath) {
+        throw new Error("Could not find the Nuxt configuration file.");
+      }
+
+      const sourceFile = loadSourceFile(configPath);
+      const config = findExportedObject(sourceFile, ["defineNuxtConfig"]);
+      if (!config) {
+        throw new Error(
+          "Could not safely update the existing Nuxt configuration file.",
+        );
+      }
+
+      const app = getOrCreateNestedObject(config, "app");
+      const head = getOrCreateNestedObject(app, "head");
+      const metaProperty = head.getProperty("meta");
+      if (!metaProperty) {
+        head.addPropertyAssignment({
+          name: "meta",
+          initializer:
+            '[{ name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" }]',
+        });
+        await sourceFile.save();
+        return;
+      }
+
+      if (!Node.isPropertyAssignment(metaProperty)) {
+        throw new Error('Cannot safely update the Nuxt "app.head.meta" property.');
+      }
+      const meta = metaProperty.getInitializer();
+      if (!Node.isArrayLiteralExpression(meta)) {
+        throw new Error('Cannot safely update the Nuxt "app.head.meta" property.');
+      }
+
+      const viewport = meta.getElements().find((element) => {
+        if (!Node.isObjectLiteralExpression(element)) {
+          return false;
+        }
+        const name = element.getProperty("name");
+        if (!Node.isPropertyAssignment(name)) {
+          return false;
+        }
+        const initializer = name.getInitializer();
+        return (
+          Node.isStringLiteral(initializer) &&
+          initializer.getLiteralValue() === "viewport"
+        );
+      });
+
+      if (!viewport || !Node.isObjectLiteralExpression(viewport)) {
+        meta.addElement(
+          '{ name: "viewport", content: "width=device-width, initial-scale=1, viewport-fit=cover" }',
+        );
+        await sourceFile.save();
+        return;
+      }
+
+      const content = viewport.getProperty("content");
+      if (!content) {
+        setObjectProperty(
+          viewport,
+          "content",
+          '"width=device-width, initial-scale=1, viewport-fit=cover"',
+        );
+        await sourceFile.save();
+        return;
+      }
+      if (!Node.isPropertyAssignment(content)) {
+        throw new Error(
+          'Cannot safely update the Nuxt viewport "content" property.',
+        );
+      }
+      const initializer = content.getInitializer();
+      if (!Node.isStringLiteral(initializer)) {
+        throw new Error(
+          'Cannot safely update the Nuxt viewport "content" property.',
+        );
+      }
+
+      const value = initializer.getLiteralValue();
+      if (!value.includes("viewport-fit=cover")) {
+        initializer.setLiteralValue(`${value}, viewport-fit=cover`);
+        await sourceFile.save();
+      }
+    },
+  };
 }
 
 function sourceViewportTarget(

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -1,4 +1,4 @@
-export type FrameworkId = "nextjs" | "tanstack-start";
+export type FrameworkId = "nextjs" | "nuxt" | "tanstack-start" | "vue";
 export type Platform = "ios" | "android";
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
 export type SetupProfile = "minimal" | "recommended";

--- a/cli/test/adapters.test.ts
+++ b/cli/test/adapters.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { nextjsAdapter } from "../src/adapters/nextjs.js";
+import { nuxtAdapter } from "../src/adapters/nuxt.js";
 import { tanstackStartAdapter } from "../src/adapters/tanstack-start.js";
+import { vueAdapter } from "../src/adapters/vue.js";
 import { configureCapacitor } from "../src/capacitor/configure.js";
 import { loadProject } from "../src/core/project.js";
 
@@ -40,6 +42,126 @@ test("configures a standard Next.js project", async () => {
   assert.match(config, /reactStrictMode: true/);
   assert.match(result.disclaimers[0].title, /do not run inside the Capacitor app/);
   assert.match(result.disclaimers[0].details.join(" "), /reachable from the device/);
+});
+
+test("configures a standard Nuxt project for a client-only static build", async () => {
+  const root = await createProject({
+    dependencies: { nuxt: "^4.0.0" },
+    scripts: { build: "nuxt build" },
+  });
+  const configPath = path.join(root, "nuxt.config.ts");
+  await writeFile(
+    configPath,
+    [
+      "export default defineNuxtConfig({",
+      '  modules: ["@nuxtjs/tailwindcss"],',
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  const project = await loadProject(root);
+  assert.equal(nuxtAdapter.detect(project), true);
+  assert.deepEqual(await nuxtAdapter.validate(project), []);
+
+  const result = await nuxtAdapter.configure(project, false);
+  const config = await readFile(configPath, "utf8");
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  ) as { scripts: Record<string, string> };
+
+  assert.equal(await nuxtAdapter.resolveWebDir(project), ".output/public");
+  assert.match(config, /ssr: false/);
+  assert.match(config, /@nuxtjs\/tailwindcss/);
+  assert.equal(packageJson.scripts.build, "nuxt generate");
+  assert.match(result.disclaimers[0].title, /do not run inside the Capacitor app/);
+  assert.match(result.disclaimers[0].details.join(" "), /Nitro handlers/);
+});
+
+test("creates a Nuxt config when the project does not have one", async () => {
+  const root = await createProject({
+    dependencies: { nuxt: "^4.0.0" },
+    scripts: { build: "nuxt build" },
+  });
+  const project = await loadProject(root);
+
+  await nuxtAdapter.configure(project, false);
+
+  assert.match(
+    await readFile(path.join(root, "nuxt.config.ts"), "utf8"),
+    /ssr: false/,
+  );
+});
+
+test("configures a standard Vue Vite project without changing it", async () => {
+  const root = await createProject({
+    dependencies: { vue: "^3.5.0" },
+    devDependencies: { vite: "^7.0.0" },
+    scripts: { build: "vite build" },
+  });
+  const packageJsonPath = path.join(root, "package.json");
+  const initialPackageJson = await readFile(packageJsonPath, "utf8");
+  const project = await loadProject(root);
+
+  assert.equal(vueAdapter.detect(project), true);
+  assert.deepEqual(await vueAdapter.validate(project), []);
+
+  const result = await vueAdapter.configure(project, false);
+
+  assert.equal(await vueAdapter.resolveWebDir(project), "dist");
+  assert.deepEqual(result.disclaimers, []);
+  assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
+});
+
+test("resolves custom Vue Vite and Vue CLI output directories", async () => {
+  const viteRoot = await createProject({
+    dependencies: { vue: "^3.5.0" },
+    devDependencies: { vite: "^7.0.0" },
+    scripts: { build: "vite build" },
+  });
+  await writeFile(
+    path.join(viteRoot, "vite.config.ts"),
+    [
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      '  build: { outDir: "build/mobile" },',
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  const vueCliRoot = await createProject({
+    dependencies: { vue: "^3.5.0" },
+    devDependencies: { "@vue/cli-service": "^5.0.0" },
+    scripts: { build: "vue-cli-service build" },
+  });
+  await writeFile(
+    path.join(vueCliRoot, "vue.config.js"),
+    'module.exports = { outputDir: "build/vue" };\n',
+  );
+
+  assert.equal(
+    await vueAdapter.resolveWebDir(await loadProject(viteRoot)),
+    "build/mobile",
+  );
+  assert.equal(
+    await vueAdapter.resolveWebDir(await loadProject(vueCliRoot)),
+    "build/vue",
+  );
+});
+
+test("does not detect Nuxt as a standalone Vue project", async () => {
+  const root = await createProject({
+    dependencies: {
+      nuxt: "^4.0.0",
+      vue: "^3.5.0",
+    },
+    devDependencies: { vite: "^7.0.0" },
+    scripts: { build: "nuxt build" },
+  });
+
+  assert.equal(vueAdapter.detect(await loadProject(root)), false);
 });
 
 test("configures TanStack Start SPA mode without removing prerender options", async () => {
@@ -123,6 +245,24 @@ test("dry-run does not write framework configuration", async () => {
   await nextjsAdapter.configure(project, true);
 
   assert.equal(await readFile(configPath, "utf8"), initial);
+});
+
+test("Nuxt dry-run does not write framework configuration or package scripts", async () => {
+  const root = await createProject({
+    dependencies: { nuxt: "^4.0.0" },
+    scripts: { build: "nuxt build" },
+  });
+  const configPath = path.join(root, "nuxt.config.ts");
+  const packageJsonPath = path.join(root, "package.json");
+  const initialConfig = "export default defineNuxtConfig({});\n";
+  const initialPackageJson = await readFile(packageJsonPath, "utf8");
+  await writeFile(configPath, initialConfig);
+
+  const project = await loadProject(root);
+  await nuxtAdapter.configure(project, true);
+
+  assert.equal(await readFile(configPath, "utf8"), initialConfig);
+  assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
 });
 
 test("creates Capacitor config and package scripts", async () => {

--- a/cli/test/framework-selection.test.ts
+++ b/cli/test/framework-selection.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { nextjsAdapter } from "../src/adapters/nextjs.js";
+import { nuxtAdapter } from "../src/adapters/nuxt.js";
 import { tanstackStartAdapter } from "../src/adapters/tanstack-start.js";
+import { vueAdapter } from "../src/adapters/vue.js";
 import {
   chooseAdapter,
   type FrameworkPrompts,
@@ -33,7 +35,12 @@ test("offers all frameworks when the detected framework is refused", async () =>
   assert.equal(adapter.id, "tanstack-start");
   assert.equal(prompts.confirmCalls, 1);
   assert.equal(prompts.selectCalls, 1);
-  assert.deepEqual(prompts.lastOptions, ["nextjs", "tanstack-start"]);
+  assert.deepEqual(prompts.lastOptions, [
+    "nextjs",
+    "nuxt",
+    "tanstack-start",
+    "vue",
+  ]);
 });
 
 test("selects a framework when detection finds nothing", async () => {
@@ -60,6 +67,26 @@ test("accepts a single detected framework with --yes", async () => {
   assert.equal(adapter.id, "tanstack-start");
 });
 
+test("accepts a detected Nuxt project with --yes", async () => {
+  const adapter = await chooseAdapter({
+    acceptDetected: true,
+    detected: [nuxtAdapter],
+    interactive: false,
+  });
+
+  assert.equal(adapter.id, "nuxt");
+});
+
+test("accepts a detected Vue project with --yes", async () => {
+  const adapter = await chooseAdapter({
+    acceptDetected: true,
+    detected: [vueAdapter],
+    interactive: false,
+  });
+
+  assert.equal(adapter.id, "vue");
+});
+
 test("requires an explicit choice outside an interactive terminal", async () => {
   await assert.rejects(
     chooseAdapter({
@@ -73,7 +100,7 @@ test("requires an explicit choice outside an interactive terminal", async () => 
 
 function createPrompts(options: {
   confirm: boolean;
-  selected: "nextjs" | "tanstack-start";
+  selected: "nextjs" | "nuxt" | "tanstack-start" | "vue";
 }): FrameworkPrompts & {
   confirmCalls: number;
   lastOptions: string[];

--- a/cli/test/init-output.test.ts
+++ b/cli/test/init-output.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -117,6 +117,122 @@ test("prints recommended setup guidance when requested", async () => {
   assert.match(text, /Your recommended Capacitor setup is ready\./);
   assert.match(text, /Review native configuration and production setup:/);
   assert.doesNotMatch(text, /Review recommended plugins/);
+});
+
+test("configures a Nuxt project with safe area from end to end", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-output-test-"));
+  const cssPath = path.join(root, "app/assets/css/main.css");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-app",
+        dependencies: { nuxt: "^4.0.0" },
+        scripts: { build: "nuxt build" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await initCommand({
+      directory: root,
+      dryRun: false,
+      framework: "nuxt",
+      interactive: false,
+      platforms: ["ios"],
+      safeArea: true,
+      skipBuild: true,
+      skipInstall: true,
+      skipNative: true,
+      yes: false,
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const nuxtConfig = await readFile(path.join(root, "nuxt.config.ts"), "utf8");
+  const capacitorConfig = await readFile(
+    path.join(root, "capacitor.config.ts"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  ) as { scripts: Record<string, string> };
+
+  assert.match(nuxtConfig, /ssr: false/);
+  assert.match(nuxtConfig, /viewport-fit=cover/);
+  assert.match(capacitorConfig, /webDir: "\.output\/public"/);
+  assert.equal(packageJson.scripts.build, "nuxt generate");
+  assert.equal(
+    packageJson.scripts["cap:sync"],
+    "npm run build && npm exec cap -- sync",
+  );
+});
+
+test("configures a Vue project with safe area from end to end", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-output-test-"));
+  const cssPath = path.join(root, "src/assets/main.css");
+  const indexPath = path.join(root, "index.html");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    indexPath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-app",
+        dependencies: { vue: "^3.5.0" },
+        devDependencies: { vite: "^7.0.0" },
+        scripts: { build: "vite build" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await initCommand({
+      directory: root,
+      dryRun: false,
+      framework: "vue",
+      interactive: false,
+      platforms: ["ios"],
+      safeArea: true,
+      skipBuild: true,
+      skipInstall: true,
+      skipNative: true,
+      yes: false,
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const capacitorConfig = await readFile(
+    path.join(root, "capacitor.config.ts"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  ) as { scripts: Record<string, string> };
+
+  assert.match(await readFile(indexPath, "utf8"), /viewport-fit=cover/);
+  assert.match(capacitorConfig, /webDir: "dist"/);
+  assert.equal(packageJson.scripts.build, "vite build");
+  assert.equal(
+    packageJson.scripts["cap:sync"],
+    "npm run build && npm exec cap -- sync",
+  );
 });
 
 function stripAnsi(value: string): string {

--- a/cli/test/safe-area.test.ts
+++ b/cli/test/safe-area.test.ts
@@ -78,6 +78,81 @@ test("adds viewport fit to a Next.js pages document", async () => {
   assert.match(await readFile(documentPath, "utf8"), /viewport-fit=cover/);
 });
 
+test("adds viewport fit to Nuxt app head configuration", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "app/assets/css/main.css");
+  const configPath = path.join(root, "nuxt.config.ts");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    configPath,
+    [
+      "export default defineNuxtConfig({",
+      "  app: {",
+      "    head: {",
+      "      meta: [{ name: 'description', content: 'Example' }],",
+      "    },",
+      "  },",
+      "});",
+      "",
+    ].join("\n"),
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "nuxt", false);
+  await configureSafeArea(project, "nuxt", false);
+
+  const css = await readFile(cssPath, "utf8");
+  const config = await readFile(configPath, "utf8");
+  assert.equal(css.match(/Capstart safe area insets/g)?.length, 1);
+  assert.equal(config.match(/viewport-fit=cover/g)?.length, 1);
+  assert.match(config, /name: 'description'/);
+});
+
+test("adds safe area CSS and viewport fit to a Vue Vite project", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/assets/main.css");
+  const indexPath = path.join(root, "index.html");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    indexPath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "vue", false);
+  await configureSafeArea(project, "vue", false);
+
+  assert.equal(
+    (await readFile(cssPath, "utf8")).match(/Capstart safe area insets/g)
+      ?.length,
+    1,
+  );
+  assert.equal(
+    (await readFile(indexPath, "utf8")).match(/viewport-fit=cover/g)?.length,
+    1,
+  );
+});
+
+test("adds viewport fit to a Vue CLI public index", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/assets/main.css");
+  const indexPath = path.join(root, "public/index.html");
+  await mkdir(path.dirname(cssPath), { recursive: true });
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    indexPath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "vue", false);
+
+  assert.match(await readFile(indexPath, "utf8"), /viewport-fit=cover/);
+});
+
 test("adds SystemBars CSS inset handling to Capacitor config", async () => {
   const root = await createProject();
   const project = await loadProject(root);


### PR DESCRIPTION
## Summary

- add a Nuxt adapter that configures client-only static generation and `.output/public`
- add a standalone Vue adapter for Vite and Vue CLI projects, including custom output directory detection
- extend safe-area configuration, framework selection, CLI documentation, and end-to-end coverage for both frameworks
- update the public website CLI, introduction, and installation documentation for Nuxt and Vue

## Impact

Capstart can now detect and configure existing Nuxt and standalone Vue applications for Capacitor. Nuxt projects are switched to `nuxt generate`; Vue projects keep their existing static build and use the detected output directory. The public documentation now describes both adapters and exposes their `--framework` values.

## Validation

### CLI

- `bun run typecheck`
- `bun test` (49 tests passed)
- `bun run build`
- compiled CLI help and invalid-framework validation checked

### Website

- `bun run types:check`
- `bun run build` (including prerender of `/docs/cli`)