### PR TITLE
[codex] Update CLI website documentation

### DIFF
--- a/capstart-website/content/docs/cli.mdx
+++ b/capstart-website/content/docs/cli.mdx
@@ -1,9 +1,9 @@
 ---
 title: CLI
-description: Add Capacitor to an existing Next.js or TanStack Start app with Capstart CLI.
+description: Add Capacitor to an existing Next.js, Nuxt, TanStack Start, or Vue app with Capstart CLI.
 ---
 
-Capstart CLI turns an existing **Next.js** or **TanStack Start** project into a Capacitor app. It detects the framework and package manager, configures a client-side production build, installs Capacitor, creates the native projects, and adds scripts for the day-to-day mobile workflow.
+Capstart CLI turns an existing **Next.js**, **Nuxt**, **TanStack Start**, or standalone **Vue** project into a Capacitor app. It detects the framework and package manager, configures a client-side production build when needed, installs Capacitor, creates the native projects, and adds scripts for the day-to-day mobile workflow.
 
 Use the CLI when you already have a web application and want to keep its existing structure. For a new React app with auth and native projects already configured, use the [Capstart boilerplate](/docs/installation#capstart-boilerplate) instead.
 
@@ -34,11 +34,14 @@ Review the changes before committing them. Framework and Capacitor configuration
 | Framework | What Capstart configures | Capacitor `webDir` |
 | --- | --- | --- |
 | Next.js | Static export, trailing slashes, and unoptimized images | `out` |
+| Nuxt | Client-only rendering and a `nuxt generate` build script | `.output/public` |
 | TanStack Start | SPA mode and an `/index.html` prerender output | `.output/public` with Nitro, otherwise `dist/client` |
+| Vue | Keeps the existing Vite or Vue CLI static build and detects literal custom output directories | `dist` by default, otherwise `build.outDir` or `outputDir` |
 
 Capacitor embeds generated web files. Request-time framework features do not run inside the installed app:
 
 - Next.js Server Actions, API routes, middleware, ISR, and request-time Server Components must stay on a deployed backend.
+- Nuxt server routes, server middleware, Nitro handlers, runtime SSR, and hybrid rendering must stay on a deployed backend.
 - TanStack Start server functions and server routes must stay on a deployed backend.
 - The mobile app must call an HTTPS API URL reachable from the device. Do not use `localhost`, because it points to the phone or emulator itself.
 
@@ -92,7 +95,7 @@ npx capstart init [directory] [options]
 
 | Option | Purpose |
 | --- | --- |
-| `--framework <nextjs\|tanstack-start>` | Select the framework without detection confirmation |
+| `--framework <nextjs\|nuxt\|tanstack-start\|vue>` | Select the framework without detection confirmation |
 | `--app-id <id>` | Set the reverse-domain native app identifier |
 | `--app-name <name>` | Set the native app name |
 | `--platforms <ios,android>` | Choose one or both native platforms |
@@ -112,6 +115,8 @@ npx capstart init . --dry-run
 npx capstart init ../my-app --app-id com.example.myapp
 npx capstart init . --platforms ios
 npx capstart init . --framework nextjs --setup recommended --safe-area
+npx capstart init . --framework nuxt --dry-run
+npx capstart init . --framework vue --safe-area
 npx capstart init . --yes
 ```
 
@@ -127,7 +132,7 @@ Capstart keeps the setup focused on the native shell and the framework build out
 
 | Area | Changes |
 | --- | --- |
-| Framework config | Configures Next.js static export or TanStack Start SPA output |
+| Framework config | Configures Next.js static export, Nuxt client-only generation, TanStack Start SPA output, or preserves an existing Vue static build |
 | Capacitor config | Creates or updates `capacitor.config.*`, including the detected `webDir` |
 | `package.json` | Installs packages and adds Capacitor scripts |
 | Native projects | Adds missing selected platforms and runs `cap sync` |

--- a/capstart-website/content/docs/index.mdx
+++ b/capstart-website/content/docs/index.mdx
@@ -13,7 +13,7 @@ Use these pages to understand what each component does, when it is useful, and h
   <Card
     title="CLI"
     href="/docs/cli"
-    description="Add Capacitor to an existing Next.js or TanStack Start app with one guided command."
+    description="Add Capacitor to an existing Next.js, Nuxt, TanStack Start, or Vue app with one guided command."
   />
   <Card
     title="Installation"
@@ -84,7 +84,7 @@ Use these pages to understand what each component does, when it is useful, and h
 
 ## How To Use This Catalog
 
-Start with the **CLI** if you already have a Next.js or TanStack Start application. It configures the framework build, Capacitor, native projects, safe areas, and the scripts you will use afterward.
+Start with the **CLI** if you already have a Next.js, Nuxt, TanStack Start, or Vue application. It configures the framework build, Capacitor, native projects, safe areas, and the scripts you will use afterward.
 
 Start with **Installation** if you are creating a new app from scratch or want to configure every layer manually. It gives you a simple baseline with Vite React, Capacitor, shadcn/ui, useful Capacitor plugins, and native project sync.
 

--- a/capstart-website/content/docs/installation.mdx
+++ b/capstart-website/content/docs/installation.mdx
@@ -7,7 +7,7 @@ description: An opinionated Vite React and Capacitor installation setup for mobi
 
 That freedom is the point: Capacitor gives you a native shell and access to native APIs, but it does not impose a very specific app architecture. Your app can stay close to the web stack you already like, and you can decide case by case when native capabilities are useful.
 
-You can start from the **Capstart boilerplate**, add Capacitor to an existing Next.js or TanStack Start app with the **Capstart CLI**, or follow the **manual setup** below. The manual path is only one opinionated approach. It is not the Capacitor way, because there is no single Capacitor way. It keeps the app simple: Vite React for the web app, Capacitor for the native shell, Tailwind with optional shadcn/ui, and **native libraries when you need them**: notifications, RevenueCat integration, social login, or any other mobile capability your app depends on.
+You can start from the **Capstart boilerplate**, add Capacitor to an existing Next.js, Nuxt, TanStack Start, or Vue app with the **Capstart CLI**, or follow the **manual setup** below. The manual path is only one opinionated approach. It is not the Capacitor way, because there is no single Capacitor way. It keeps the app simple: Vite React for the web app, Capacitor for the native shell, Tailwind with optional shadcn/ui, and **native libraries when you need them**: notifications, RevenueCat integration, social login, or any other mobile capability your app depends on.
 
 ## Choose your starting point
 
@@ -28,7 +28,7 @@ You can start from the **Capstart boilerplate**, add Capacitor to an existing Ne
     <div className="flex flex-col gap-2">
       <h3 className="text-lg font-semibold text-fd-foreground">Capstart CLI</h3>
       <p className="text-sm leading-relaxed text-fd-muted-foreground">
-        Add Capacitor to an existing Next.js or TanStack Start app with framework detection, native projects, safe areas, and generated scripts.
+        Add Capacitor to an existing Next.js, Nuxt, TanStack Start, or Vue app with framework detection, native projects, safe areas, and generated scripts.
       </p>
     </div>
     <a className="mt-auto inline-flex text-sm font-medium text-fd-primary" href="/docs/cli">


### PR DESCRIPTION
## Summary

- document Nuxt and standalone Vue support on the public CLI page
- describe each adapter's generated `webDir` and framework-specific behavior
- update the documentation index and installation entry points so they list all supported frameworks

## Validation

- `bun run types:check`
- `bun run build` (including prerender of `/docs/cli`)