### PR TITLE
[codex] Prepare CLI 0.3.0 release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capstart",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Add Capacitor to existing web framework projects.",
   "type": "module",
   "packageManager": "bun@1.3.9",

--- a/cli/package.json
+++ b/cli/package.json
@@ -29,7 +29,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/cli.ts --format esm --dts --clean",
+    "build": "tsup src/cli.ts --format esm --clean",
     "dev": "bun src/cli.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { Command, InvalidArgumentError } from "commander";
+import packageJson from "../package.json";
 import { initCommand } from "./commands/init.js";
 import { logger } from "./core/logger.js";
 import type {
@@ -14,7 +15,7 @@ const program = new Command();
 program
   .name("capstart")
   .description("Add Capacitor to an existing web application.")
-  .version("0.1.0");
+  .version(packageJson.version);
 
 program
   .command("init")


### PR DESCRIPTION
## Summary

- stop generating an unused declaration file for the CLI-only package
- avoid the deprecated `baseUrl` option injected by tsup's DTS build under TypeScript 6.0.3
- bump the CLI package to `0.3.0` because `0.2.1` is already published
- source `capstart --version` from `package.json` instead of the stale hard-coded `0.1.0`

## Root cause

The package exposes only a binary and has no typed library API, but its build passed `--dts` to tsup. During declaration generation, tsup injects `baseUrl`, which TypeScript 6.0.3 reports as an error because the option is deprecated for TypeScript 7.

## Validation

- `bun run prepublishOnly` (49 tests passed)
- `node dist/cli.js --version` outputs `0.3.0`
- `bun publish --dry-run` packed `capstart@0.3.0` successfully