### PR TITLE
[codex] Add Svelte and SvelteKit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ capstart/
 ### `cli`
 
 The `capstart` command-line tool configures existing Next.js, Nuxt, React +
-Vite, TanStack Start, and Vue applications for Capacitor.
+Vite, Svelte + Vite, SvelteKit, TanStack Start, and Vue applications for
+Capacitor.
 
 ```bash
 npx capstart init ..

--- a/capstart-website/content/docs/cli.mdx
+++ b/capstart-website/content/docs/cli.mdx
@@ -1,9 +1,9 @@
 ---
 title: CLI
-description: Add Capacitor to an existing Next.js, Nuxt, React + Vite, TanStack Start, or Vue app with Capstart CLI.
+description: Add Capacitor to an existing Next.js, Nuxt, React + Vite, Svelte + Vite, SvelteKit, TanStack Start, or Vue app with Capstart CLI.
 ---
 
-Capstart CLI turns an existing **Next.js**, **Nuxt**, standalone **React + Vite**, **TanStack Start**, or standalone **Vue** project into a Capacitor app. It detects the framework and package manager, configures a client-side production build when needed, installs Capacitor, creates the native projects, and adds scripts for the day-to-day mobile workflow.
+Capstart CLI turns an existing **Next.js**, **Nuxt**, standalone **React + Vite**, **Svelte + Vite**, **SvelteKit**, **TanStack Start**, or standalone **Vue** project into a Capacitor app. It detects the framework and package manager, configures a client-side production build when needed, installs Capacitor, creates the native projects, and adds scripts for the day-to-day mobile workflow.
 
 Use the CLI when you already have a web application and want to keep its existing structure. For a new React app with auth and native projects already configured, use the [Capstart boilerplate](/docs/installation#capstart-boilerplate) instead.
 
@@ -36,6 +36,8 @@ Review the changes before committing them. Framework and Capacitor configuration
 | Next.js | Static export, trailing slashes, and unoptimized images | `out` |
 | Nuxt | Client-only rendering and a `nuxt generate` build script | `.output/public` |
 | React + Vite | Keeps the existing static build and detects a literal custom output directory | `dist` by default, otherwise `build.outDir` |
+| Svelte + Vite | Keeps the existing static build and detects a literal custom output directory | `dist` by default, otherwise `build.outDir` |
+| SvelteKit | SPA mode with `adapter-static`, runtime SSR disabled, and an `index.html` fallback | `build` by default, otherwise matching literal `pages` and `assets` directories |
 | TanStack Start | SPA mode and an `/index.html` prerender output | `.output/public` with Nitro, otherwise `dist/client` |
 | Vue | Keeps the existing Vite or Vue CLI static build and detects literal custom output directories | `dist` by default, otherwise `build.outDir` or `outputDir` |
 
@@ -45,6 +47,7 @@ Capacitor embeds generated web files. Request-time framework features do not run
 
 - Next.js Server Actions, API routes, middleware, ISR, and request-time Server Components must stay on a deployed backend.
 - Nuxt server routes, server middleware, Nitro handlers, runtime SSR, and hybrid rendering must stay on a deployed backend.
+- SvelteKit server routes, server load functions, form actions, remote functions, and runtime SSR must stay on a deployed backend.
 - TanStack Start server functions and server routes must stay on a deployed backend.
 - The mobile app must call an HTTPS API URL reachable from the device. Do not use `localhost`, because it points to the phone or emulator itself.
 
@@ -98,7 +101,7 @@ npx capstart init [directory] [options]
 
 | Option | Purpose |
 | --- | --- |
-| `--framework <nextjs\|nuxt\|react-vite\|tanstack-start\|vue>` | Select the framework without detection confirmation |
+| `--framework <nextjs\|nuxt\|react-vite\|svelte\|sveltekit\|tanstack-start\|vue>` | Select the framework without detection confirmation |
 | `--app-id <id>` | Set the reverse-domain native app identifier |
 | `--app-name <name>` | Set the native app name |
 | `--platforms <ios,android>` | Choose one or both native platforms |
@@ -120,6 +123,7 @@ npx capstart init . --platforms ios
 npx capstart init . --framework nextjs --setup recommended --safe-area
 npx capstart init . --framework nuxt --dry-run
 npx capstart init . --framework react-vite --safe-area
+npx capstart init . --framework sveltekit --safe-area
 npx capstart init . --framework vue --safe-area
 npx capstart init . --yes
 ```
@@ -136,7 +140,7 @@ Capstart keeps the setup focused on the native shell and the framework build out
 
 | Area | Changes |
 | --- | --- |
-| Framework config | Configures Next.js static export, Nuxt client-only generation, TanStack Start SPA output, or preserves an existing React + Vite or Vue static build |
+| Framework config | Configures Next.js static export, Nuxt client-only generation, SvelteKit and TanStack Start SPA output, or preserves an existing React + Vite, Svelte + Vite, or Vue static build |
 | Capacitor config | Creates or updates `capacitor.config.*`, including the detected `webDir` |
 | `package.json` | Installs packages and adds Capacitor scripts |
 | Native projects | Adds missing selected platforms and runs `cap sync` |

--- a/capstart-website/content/docs/index.mdx
+++ b/capstart-website/content/docs/index.mdx
@@ -13,7 +13,7 @@ Use these pages to understand what each component does, when it is useful, and h
   <Card
     title="CLI"
     href="/docs/cli"
-    description="Add Capacitor to an existing Next.js, Nuxt, React + Vite, TanStack Start, or Vue app with one guided command."
+    description="Add Capacitor to an existing Next.js, Nuxt, React + Vite, Svelte + Vite, SvelteKit, TanStack Start, or Vue app with one guided command."
   />
   <Card
     title="Installation"
@@ -84,7 +84,7 @@ Use these pages to understand what each component does, when it is useful, and h
 
 ## How To Use This Catalog
 
-Start with the **CLI** if you already have a Next.js, Nuxt, React + Vite, TanStack Start, or Vue application. It configures the framework build, Capacitor, native projects, safe areas, and the scripts you will use afterward.
+Start with the **CLI** if you already have a Next.js, Nuxt, React + Vite, Svelte + Vite, SvelteKit, TanStack Start, or Vue application. It configures the framework build, Capacitor, native projects, safe areas, and the scripts you will use afterward.
 
 Start with **Installation** if you are creating a new app from scratch or want to configure every layer manually. It gives you a simple baseline with Vite React, Capacitor, shadcn/ui, useful Capacitor plugins, and native project sync.
 

--- a/capstart-website/content/docs/installation.mdx
+++ b/capstart-website/content/docs/installation.mdx
@@ -7,7 +7,7 @@ description: An opinionated Vite React and Capacitor installation setup for mobi
 
 That freedom is the point: Capacitor gives you a native shell and access to native APIs, but it does not impose a very specific app architecture. Your app can stay close to the web stack you already like, and you can decide case by case when native capabilities are useful.
 
-You can start from the **Capstart boilerplate**, add Capacitor to an existing Next.js, Nuxt, React + Vite, TanStack Start, or Vue app with the **Capstart CLI**, or follow the **manual setup** below. The manual path is only one opinionated approach. It is not the Capacitor way, because there is no single Capacitor way. It keeps the app simple: Vite React for the web app, Capacitor for the native shell, Tailwind with optional shadcn/ui, and **native libraries when you need them**: notifications, RevenueCat integration, social login, or any other mobile capability your app depends on.
+You can start from the **Capstart boilerplate**, add Capacitor to an existing Next.js, Nuxt, React + Vite, Svelte + Vite, SvelteKit, TanStack Start, or Vue app with the **Capstart CLI**, or follow the **manual setup** below. The manual path is only one opinionated approach. It is not the Capacitor way, because there is no single Capacitor way. It keeps the app simple: Vite React for the web app, Capacitor for the native shell, Tailwind with optional shadcn/ui, and **native libraries when you need them**: notifications, RevenueCat integration, social login, or any other mobile capability your app depends on.
 
 ## Choose your starting point
 
@@ -28,7 +28,7 @@ You can start from the **Capstart boilerplate**, add Capacitor to an existing Ne
     <div className="flex flex-col gap-2">
       <h3 className="text-lg font-semibold text-fd-foreground">Capstart CLI</h3>
       <p className="text-sm leading-relaxed text-fd-muted-foreground">
-        Add Capacitor to an existing Next.js, Nuxt, React + Vite, TanStack Start, or Vue app with framework detection, native projects, safe areas, and generated scripts.
+        Add Capacitor to an existing Next.js, Nuxt, React + Vite, Svelte + Vite, SvelteKit, TanStack Start, or Vue app with framework detection, native projects, safe areas, and generated scripts.
       </p>
     </div>
     <a className="mt-auto inline-flex text-sm font-medium text-fd-primary" href="/docs/cli">

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,7 @@
 # Capstart CLI
 
-Add Capacitor to an existing Next.js, Nuxt, React + Vite, TanStack Start, or Vue application.
+Add Capacitor to an existing Next.js, Nuxt, React + Vite, Svelte + Vite,
+SvelteKit, TanStack Start, or Vue application.
 
 ```bash
 npx capstart init ..
@@ -46,7 +47,7 @@ changes the project:
 ```
 
 If the detection is refused, Capstart lets you choose between Next.js, Nuxt,
-React + Vite, TanStack Start, and Vue.
+React + Vite, Svelte + Vite, SvelteKit, TanStack Start, and Vue.
 
 ## Supported frameworks
 
@@ -55,6 +56,12 @@ React + Vite, TanStack Start, and Vue.
   script to `nuxt generate` and uses `.output/public`.
 - Standalone React projects built with Vite. Capstart keeps the existing static
   build, uses `dist` by default, and detects a literal custom `build.outDir`.
+- Svelte + Vite projects. Capstart keeps the existing static build, uses
+  `dist` by default, and detects a literal custom `build.outDir`.
+- SvelteKit projects that can use SPA mode. Capstart switches the project to
+  `@sveltejs/adapter-static`, generates an `index.html` fallback, disables
+  runtime SSR, and uses `build` by default. Existing literal `pages` and
+  matching `assets` directories are preserved.
 - TanStack Start projects that can use SPA mode. Capstart uses `.output/public`
   when the Vite config includes Nitro, and `dist/client` otherwise.
 - Standalone Vue projects built with Vite or Vue CLI. Capstart uses `dist` by
@@ -82,6 +89,8 @@ npx capstart init . --platforms ios
 npx capstart init . --setup recommended
 npx capstart init . --framework nuxt --dry-run
 npx capstart init . --framework react-vite --dry-run
+npx capstart init . --framework svelte --dry-run
+npx capstart init . --framework sveltekit --dry-run
 npx capstart init . --framework tanstack-start --dry-run
 npx capstart init . --framework vue --dry-run
 npx capstart init . --yes
@@ -90,7 +99,7 @@ npx capstart init . --yes
 Useful options:
 
 ```text
---framework <nextjs|nuxt|react-vite|tanstack-start|vue>
+--framework <nextjs|nuxt|react-vite|svelte|sveltekit|tanstack-start|vue>
 --app-id <id>
 --app-name <name>
 --platforms <ios,android>

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,6 +18,8 @@
     "nextjs",
     "nuxt",
     "react",
+    "svelte",
+    "sveltekit",
     "tanstack-start",
     "vite",
     "vue"

--- a/cli/src/adapters/index.ts
+++ b/cli/src/adapters/index.ts
@@ -6,6 +6,8 @@ import type {
 import { nextjsAdapter } from "./nextjs.js";
 import { nuxtAdapter } from "./nuxt.js";
 import { reactViteAdapter } from "./react-vite.js";
+import { svelteAdapter } from "./svelte.js";
+import { svelteKitAdapter } from "./sveltekit.js";
 import { tanstackStartAdapter } from "./tanstack-start.js";
 import { vueAdapter } from "./vue.js";
 
@@ -13,6 +15,8 @@ const adapters: FrameworkAdapter[] = [
   nextjsAdapter,
   nuxtAdapter,
   reactViteAdapter,
+  svelteAdapter,
+  svelteKitAdapter,
   tanstackStartAdapter,
   vueAdapter,
 ];

--- a/cli/src/adapters/svelte.ts
+++ b/cli/src/adapters/svelte.ts
@@ -1,0 +1,29 @@
+import { hasDependency } from "../core/project.js";
+import type { FrameworkAdapter } from "../core/types.js";
+import {
+  resolveViteWebDir,
+  validateViteProject,
+} from "./vite-config.js";
+
+export const svelteAdapter: FrameworkAdapter = {
+  id: "svelte",
+  label: "Svelte + Vite",
+
+  detect(project) {
+    return (
+      hasDependency(project, "svelte") &&
+      hasDependency(project, "vite") &&
+      !hasDependency(project, "@sveltejs/kit")
+    );
+  },
+
+  resolveWebDir: resolveViteWebDir,
+
+  async validate(project) {
+    return validateViteProject(project);
+  },
+
+  async configure() {
+    return { disclaimers: [] };
+  },
+};

--- a/cli/src/adapters/sveltekit.ts
+++ b/cli/src/adapters/sveltekit.ts
@@ -1,0 +1,580 @@
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  Node,
+  type ObjectLiteralExpression,
+  type SourceFile,
+  SyntaxKind,
+  VariableDeclarationKind,
+} from "ts-morph";
+import {
+  findConfigFile,
+  findExportedObject,
+  getOrCreateNestedObject,
+  loadSourceFile,
+  setObjectProperty,
+} from "../core/ast.js";
+import {
+  hasDependency,
+  pathExists,
+  savePackageJson,
+} from "../core/project.js";
+import type {
+  Diagnostic,
+  FrameworkAdapter,
+  ProjectContext,
+} from "../core/types.js";
+import {
+  getStringProperty,
+  validateViteProject,
+} from "./vite-config.js";
+
+const viteConfigNames = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.mjs",
+  "vite.config.js",
+];
+const svelteConfigNames = [
+  "svelte.config.ts",
+  "svelte.config.mts",
+  "svelte.config.mjs",
+  "svelte.config.js",
+];
+const rootLayoutNames = [
+  "src/routes/+layout.ts",
+  "src/routes/+layout.js",
+];
+const staticAdapterPackage = "@sveltejs/adapter-static";
+
+interface ActiveConfig {
+  config?: ObjectLiteralExpression;
+  kind: "svelte-config" | "vite";
+  sourceFile: SourceFile;
+  target?: ObjectLiteralExpression;
+}
+
+export const svelteKitAdapter: FrameworkAdapter = {
+  id: "sveltekit",
+  label: "SvelteKit",
+
+  detect(project) {
+    return hasDependency(project, "@sveltejs/kit");
+  },
+
+  async resolveWebDir(project) {
+    const active = await findActiveConfig(project);
+    return resolveStaticOutputDir(active);
+  },
+
+  async validate(project) {
+    const diagnostics: Diagnostic[] = [...validateViteProject(project)];
+
+    try {
+      const active = await findActiveConfig(project);
+      validateActiveConfig(active);
+      resolveStaticOutputDir(active);
+    } catch (error) {
+      diagnostics.push({
+        level: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    const rootLayoutPath = await findConfigFile(project.root, rootLayoutNames);
+    if (rootLayoutPath) {
+      const sourceFile = loadSourceFile(rootLayoutPath);
+      const ssr = sourceFile.getVariableDeclaration("ssr");
+      if (ssr && !ssr.getVariableStatement()?.isExported()) {
+        diagnostics.push({
+          level: "error",
+          message:
+            'Cannot safely update the root SvelteKit layout because "ssr" is not exported.',
+        });
+      }
+    }
+
+    const serverFiles = await findServerRouteFiles(project.root);
+    if (serverFiles.length > 0) {
+      diagnostics.push({
+        level: "warning",
+        message: `Detected SvelteKit server route files that will not run inside the Capacitor app: ${serverFiles.slice(0, 3).join(", ")}${serverFiles.length > 3 ? ", ..." : ""}`,
+      });
+    }
+
+    return diagnostics;
+  },
+
+  async configure(project, dryRun) {
+    const active = await findActiveConfig(project);
+    const target = getEditableTarget(active);
+
+    configureStaticAdapter(active.sourceFile, target);
+    await configureRootLayout(project, dryRun);
+    configureAdapterDependency(project);
+
+    if (!dryRun) {
+      await active.sourceFile.save();
+    }
+    await savePackageJson(project, dryRun);
+
+    return {
+      disclaimers: [
+        {
+          title:
+            "SvelteKit server features do not run inside the Capacitor app.",
+          details: [
+            "Move +page.server, +layout.server, +server, form actions, and remote functions to a deployed backend.",
+            "Runtime SSR is disabled and the mobile build is served through a client-rendered SPA fallback.",
+            "Configure the mobile app to call an HTTPS API URL that is reachable from the device.",
+            'Do not use "localhost" for the backend URL: on a phone or emulator, it points to the device itself.',
+          ],
+        },
+      ],
+    };
+  },
+};
+
+async function findActiveConfig(project: ProjectContext): Promise<ActiveConfig> {
+  const viteConfigPath = await findConfigFile(project.root, viteConfigNames);
+  if (!viteConfigPath) {
+    throw new Error("Could not find a SvelteKit Vite configuration file.");
+  }
+
+  const viteSourceFile = loadSourceFile(viteConfigPath);
+  const svelteKitCall = findSvelteKitCall(viteSourceFile);
+  if (!svelteKitCall) {
+    throw new Error(
+      "Could not find sveltekit() in the Vite configuration file.",
+    );
+  }
+
+  const argument = svelteKitCall.getArguments()[0];
+  if (argument) {
+    if (!Node.isObjectLiteralExpression(argument)) {
+      throw new Error(
+        "Cannot safely update sveltekit() because its configuration is not an object literal.",
+      );
+    }
+    return {
+      config: argument,
+      kind: "vite",
+      sourceFile: viteSourceFile,
+      target: argument,
+    };
+  }
+
+  const svelteConfigPath = await findConfigFile(project.root, svelteConfigNames);
+  if (svelteConfigPath) {
+    const sourceFile = loadSourceFile(svelteConfigPath);
+    const config = findExportedObject(sourceFile);
+    if (!config) {
+      throw new Error(
+        "The existing SvelteKit config is too dynamic to update safely. Export a config object before running Capstart.",
+      );
+    }
+    return {
+      config,
+      kind: "svelte-config",
+      sourceFile,
+      target: getOptionalObjectProperty(config, "kit"),
+    };
+  }
+
+  return {
+    kind: "vite",
+    sourceFile: viteSourceFile,
+  };
+}
+
+function findSvelteKitCall(sourceFile: SourceFile) {
+  const names = new Set(
+    sourceFile
+      .getImportDeclarations()
+      .filter(
+        (declaration) =>
+          declaration.getModuleSpecifierValue() === "@sveltejs/kit/vite",
+      )
+      .flatMap((declaration) =>
+        declaration
+          .getNamedImports()
+          .filter((namedImport) => namedImport.getName() === "sveltekit")
+          .map(
+            (namedImport) =>
+              namedImport.getAliasNode()?.getText() ?? namedImport.getName(),
+          ),
+      ),
+  );
+
+  return sourceFile
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .find((call) => names.has(call.getExpression().getText()));
+}
+
+function getEditableTarget(active: ActiveConfig): ObjectLiteralExpression {
+  if (active.kind === "svelte-config") {
+    if (!active.config) {
+      throw new Error("Could not find the SvelteKit configuration object.");
+    }
+    return getOrCreateNestedObject(active.config, "kit");
+  }
+
+  if (active.target) {
+    return active.target;
+  }
+
+  const call = findSvelteKitCall(active.sourceFile);
+  if (!call) {
+    throw new Error("Could not find sveltekit() in the Vite config.");
+  }
+  call.addArgument("{}");
+  const argument = call.getArguments()[0];
+  if (!Node.isObjectLiteralExpression(argument)) {
+    throw new Error("Could not create the SvelteKit configuration object.");
+  }
+  return argument;
+}
+
+function validateActiveConfig(active: ActiveConfig): void {
+  const adapterImports = getAdapterImports(active.sourceFile);
+  if (adapterImports.length > 1) {
+    throw new Error(
+      "The SvelteKit config imports multiple adapters and is too dynamic to update safely.",
+    );
+  }
+  if (adapterImports[0] && !adapterImports[0].getDefaultImport()) {
+    throw new Error(
+      "The configured SvelteKit adapter does not use a default import.",
+    );
+  }
+
+  if (active.kind === "svelte-config" && active.config && !active.target) {
+    const kitProperty = active.config.getProperty("kit");
+    if (kitProperty) {
+      throw new Error(
+        'Cannot safely merge the SvelteKit "kit" configuration property.',
+      );
+    }
+  }
+
+  const target = active.target;
+  const adapterProperty = target?.getProperty("adapter");
+  if (!adapterProperty) {
+    return;
+  }
+  if (!Node.isPropertyAssignment(adapterProperty)) {
+    throw new Error(
+      'Cannot safely update the SvelteKit "adapter" configuration property.',
+    );
+  }
+
+  const adapterCall = adapterProperty.getInitializer();
+  if (!Node.isCallExpression(adapterCall)) {
+    throw new Error(
+      'Cannot safely update the SvelteKit "adapter" configuration property.',
+    );
+  }
+
+  const adapterImport = adapterImports[0];
+  if (
+    !adapterImport ||
+    adapterCall.getExpression().getText() !==
+      adapterImport.getDefaultImport()?.getText()
+  ) {
+    throw new Error(
+      "The configured SvelteKit adapter is too dynamic to replace safely.",
+    );
+  }
+
+  if (adapterImport.getModuleSpecifierValue() === staticAdapterPackage) {
+    const options = adapterCall.getArguments()[0];
+    if (options && !Node.isObjectLiteralExpression(options)) {
+      throw new Error(
+        "Cannot safely update adapter-static because its options are not an object literal.",
+      );
+    }
+  }
+}
+
+function configureStaticAdapter(
+  sourceFile: SourceFile,
+  target: ObjectLiteralExpression,
+): void {
+  const adapterImports = getAdapterImports(sourceFile);
+  if (adapterImports.length > 1) {
+    throw new Error(
+      "The SvelteKit config imports multiple adapters and is too dynamic to update safely.",
+    );
+  }
+
+  const existingImport = adapterImports[0];
+  const wasStatic =
+    existingImport?.getModuleSpecifierValue() === staticAdapterPackage;
+  const removeAutoComments =
+    existingImport?.getModuleSpecifierValue() === "@sveltejs/adapter-auto";
+  let adapterName = existingImport?.getDefaultImport()?.getText();
+
+  if (existingImport) {
+    if (!adapterName) {
+      throw new Error(
+        "The configured SvelteKit adapter does not use a default import.",
+      );
+    }
+    existingImport.setModuleSpecifier(staticAdapterPackage);
+  } else {
+    adapterName = chooseAdapterName(sourceFile);
+    sourceFile.addImportDeclaration({
+      defaultImport: adapterName,
+      moduleSpecifier: staticAdapterPackage,
+    });
+  }
+
+  if (!adapterName) {
+    throw new Error("Could not configure the SvelteKit static adapter.");
+  }
+
+  const adapterProperty = target.getProperty("adapter");
+  if (!adapterProperty || !wasStatic) {
+    setObjectProperty(
+      target,
+      "adapter",
+      `${adapterName}({ fallback: "index.html" })`,
+    );
+    if (removeAutoComments) {
+      removeAdapterAutoComments(sourceFile, target);
+    }
+    return;
+  }
+
+  if (!Node.isPropertyAssignment(adapterProperty)) {
+    throw new Error(
+      'Cannot safely update the SvelteKit "adapter" configuration property.',
+    );
+  }
+  const adapterCall = adapterProperty.getInitializer();
+  if (!Node.isCallExpression(adapterCall)) {
+    throw new Error(
+      'Cannot safely update the SvelteKit "adapter" configuration property.',
+    );
+  }
+  adapterCall.getExpression().replaceWithText(adapterName);
+
+  let options = adapterCall.getArguments()[0];
+  if (!options) {
+    adapterCall.addArgument("{}");
+    options = adapterCall.getArguments()[0];
+  }
+  if (!Node.isObjectLiteralExpression(options)) {
+    throw new Error(
+      "Cannot safely update adapter-static because its options are not an object literal.",
+    );
+  }
+  setObjectProperty(options, "fallback", '"index.html"');
+}
+
+function removeAdapterAutoComments(
+  sourceFile: SourceFile,
+  target: ObjectLiteralExpression,
+): void {
+  const adapterProperty = target.getProperty("adapter");
+  if (!adapterProperty) {
+    return;
+  }
+
+  const staleComments = adapterProperty
+    .getLeadingCommentRanges()
+    .filter((comment) => {
+      const text = comment.getText();
+      return (
+        text.includes("adapter-auto only supports") ||
+        text.includes("If your environment is not supported") ||
+        text.includes("See https://svelte.dev/docs/kit/adapters")
+      );
+    });
+  const text = sourceFile.getFullText();
+  const lineRanges = staleComments.map((comment) => {
+    const start = text.lastIndexOf("\n", comment.getPos() - 1) + 1;
+    const newline = text.indexOf("\n", comment.getEnd());
+    return [start, newline === -1 ? comment.getEnd() : newline + 1] as [
+      number,
+      number,
+    ];
+  });
+
+  for (const range of lineRanges.reverse()) {
+    sourceFile.replaceText(range, "");
+  }
+}
+
+function chooseAdapterName(sourceFile: SourceFile): string {
+  const identifiers = new Set(
+    sourceFile
+      .getDescendantsOfKind(SyntaxKind.Identifier)
+      .map((identifier) => identifier.getText()),
+  );
+  return identifiers.has("adapter") ? "staticAdapter" : "adapter";
+}
+
+function getAdapterImports(sourceFile: SourceFile) {
+  return sourceFile.getImportDeclarations().filter((declaration) => {
+    const specifier = declaration.getModuleSpecifierValue();
+    return specifier.startsWith("@sveltejs/adapter-");
+  });
+}
+
+function resolveStaticOutputDir(active: ActiveConfig): string {
+  const adapterImport = getAdapterImports(active.sourceFile)[0];
+  if (
+    !active.target ||
+    adapterImport?.getModuleSpecifierValue() !== staticAdapterPackage
+  ) {
+    return "build";
+  }
+
+  const adapterProperty = active.target.getProperty("adapter");
+  if (!Node.isPropertyAssignment(adapterProperty)) {
+    return "build";
+  }
+  const adapterCall = adapterProperty.getInitializer();
+  if (!Node.isCallExpression(adapterCall)) {
+    return "build";
+  }
+  const options = adapterCall.getArguments()[0];
+  if (!options) {
+    return "build";
+  }
+  if (!Node.isObjectLiteralExpression(options)) {
+    throw new Error(
+      "Cannot resolve the SvelteKit output directory because adapter-static options are dynamic.",
+    );
+  }
+
+  const pages = readOptionalStringProperty(options, "pages") ?? "build";
+  const assets = readOptionalStringProperty(options, "assets") ?? pages;
+  if (pages !== assets) {
+    throw new Error(
+      "Capacitor requires SvelteKit adapter-static pages and assets to use the same output directory.",
+    );
+  }
+  return pages;
+}
+
+function readOptionalStringProperty(
+  object: ObjectLiteralExpression,
+  name: string,
+): string | undefined {
+  if (!object.getProperty(name)) {
+    return undefined;
+  }
+  const value = getStringProperty(object, name);
+  if (value === undefined) {
+    throw new Error(
+      `Cannot resolve the SvelteKit output directory because adapter-static "${name}" is dynamic.`,
+    );
+  }
+  return value;
+}
+
+function getOptionalObjectProperty(
+  object: ObjectLiteralExpression,
+  name: string,
+): ObjectLiteralExpression | undefined {
+  const property = object.getProperty(name);
+  if (!Node.isPropertyAssignment(property)) {
+    return undefined;
+  }
+  const initializer = property.getInitializer();
+  return Node.isObjectLiteralExpression(initializer) ? initializer : undefined;
+}
+
+async function configureRootLayout(
+  project: ProjectContext,
+  dryRun: boolean,
+): Promise<void> {
+  const rootLayoutPath = await findConfigFile(project.root, rootLayoutNames);
+  if (!rootLayoutPath) {
+    const routesDir = path.join(project.root, "src/routes");
+    const extension = (await pathExists(path.join(project.root, "tsconfig.json")))
+      ? "ts"
+      : "js";
+    if (!dryRun) {
+      await mkdir(routesDir, { recursive: true });
+      await writeFile(
+        path.join(routesDir, `+layout.${extension}`),
+        "export const ssr = false;\n",
+      );
+    }
+    return;
+  }
+
+  const sourceFile = loadSourceFile(rootLayoutPath);
+  const ssr = sourceFile.getVariableDeclaration("ssr");
+  if (ssr) {
+    if (!ssr.getVariableStatement()?.isExported()) {
+      throw new Error(
+        'Cannot safely update the root SvelteKit layout because "ssr" is not exported.',
+      );
+    }
+    ssr.setInitializer("false");
+  } else {
+    sourceFile.addVariableStatement({
+      declarationKind: VariableDeclarationKind.Const,
+      declarations: [{ name: "ssr", initializer: "false" }],
+      isExported: true,
+    });
+  }
+
+  if (!dryRun) {
+    await sourceFile.save();
+  }
+}
+
+function configureAdapterDependency(project: ProjectContext): void {
+  const existingVersion =
+    project.packageJson.devDependencies?.[staticAdapterPackage] ??
+    project.packageJson.dependencies?.[staticAdapterPackage];
+
+  for (const group of [
+    project.packageJson.dependencies,
+    project.packageJson.devDependencies,
+  ]) {
+    if (!group) {
+      continue;
+    }
+    for (const dependency of Object.keys(group)) {
+      if (dependency.startsWith("@sveltejs/adapter-")) {
+        delete group[dependency];
+      }
+    }
+  }
+
+  project.packageJson.devDependencies ??= {};
+  project.packageJson.devDependencies[staticAdapterPackage] =
+    existingVersion ?? "^3.0.0";
+}
+
+async function findServerRouteFiles(root: string): Promise<string[]> {
+  const routesRoot = path.join(root, "src/routes");
+  if (!(await pathExists(routesRoot))) {
+    return [];
+  }
+
+  const found: string[] = [];
+  await walk(routesRoot, "");
+  return found.sort();
+
+  async function walk(directory: string, relative: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const relativePath = path.join(relative, entry.name);
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(absolutePath, relativePath);
+      } else if (
+        /^\+(?:page|layout)\.server\.(?:js|ts)$/.test(entry.name) ||
+        /^\+server\.(?:js|ts)$/.test(entry.name)
+      ) {
+        found.push(path.join("src/routes", relativePath));
+      }
+    }
+  }
+}

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -23,7 +23,7 @@ program
   .argument("[directory]", "project directory", ".")
   .option(
     "-f, --framework <framework>",
-    "framework adapter: nextjs, nuxt, react-vite, tanstack-start, or vue",
+    "framework adapter: nextjs, nuxt, react-vite, svelte, sveltekit, tanstack-start, or vue",
     parseFramework,
   )
   .option("--app-id <id>", "native application id, for example com.example.app")
@@ -73,13 +73,15 @@ function parseFramework(value: string): FrameworkId {
     value === "nextjs" ||
     value === "nuxt" ||
     value === "react-vite" ||
+    value === "svelte" ||
+    value === "sveltekit" ||
     value === "tanstack-start" ||
     value === "vue"
   ) {
     return value;
   }
   throw new InvalidArgumentError(
-    'Framework must be "nextjs", "nuxt", "react-vite", "tanstack-start", or "vue".',
+    'Framework must be "nextjs", "nuxt", "react-vite", "svelte", "sveltekit", "tanstack-start", or "vue".',
   );
 }
 

--- a/cli/src/core/ast.ts
+++ b/cli/src/core/ast.ts
@@ -124,7 +124,9 @@ function resolveObjectExpression(
   }
 
   if (Node.isIdentifier(expression)) {
-    const declaration = expression.getDefinitions()[0]?.getDeclarationNode();
+    const declaration =
+      expression.getSourceFile().getVariableDeclaration(expression.getText()) ??
+      expression.getDefinitions()[0]?.getDeclarationNode();
     if (Node.isVariableDeclaration(declaration)) {
       const initializer = declaration.getInitializer();
       return initializer

--- a/cli/src/core/framework-selection.ts
+++ b/cli/src/core/framework-selection.ts
@@ -56,7 +56,7 @@ export async function chooseAdapter(options: {
     }
 
     throw new Error(
-      "Framework selection requires an interactive terminal. Pass --framework nextjs, --framework nuxt, --framework react-vite, --framework tanstack-start, or --framework vue.",
+      "Framework selection requires an interactive terminal. Pass --framework nextjs, --framework nuxt, --framework react-vite, --framework svelte, --framework sveltekit, --framework tanstack-start, or --framework vue.",
     );
   }
 

--- a/cli/src/core/safe-area.ts
+++ b/cli/src/core/safe-area.ts
@@ -50,6 +50,21 @@ const globalCssCandidates: Record<FrameworkId, string[]> = {
     "src/globals.css",
     "src/styles/globals.css",
   ],
+  svelte: [
+    "src/app.css",
+    "src/style.css",
+    "src/styles.css",
+    "src/index.css",
+    "src/global.css",
+    "src/styles/globals.css",
+  ],
+  sveltekit: [
+    "src/app.css",
+    "src/routes/layout.css",
+    "src/styles.css",
+    "src/global.css",
+    "src/styles/globals.css",
+  ],
   "tanstack-start": [
     "src/styles.css",
     "src/index.css",
@@ -129,12 +144,21 @@ async function findViewportTarget(
     return rootRoutePath ? sourceViewportTarget(rootRoutePath) : undefined;
   }
 
-  if (framework === "react-vite" || framework === "vue") {
+  if (
+    framework === "react-vite" ||
+    framework === "svelte" ||
+    framework === "vue"
+  ) {
     const indexPath = await findConfigFile(root, [
       "index.html",
       "public/index.html",
     ]);
     return indexPath ? markupViewportTarget(indexPath) : undefined;
+  }
+
+  if (framework === "sveltekit") {
+    const appTemplatePath = await findConfigFile(root, ["src/app.html"]);
+    return appTemplatePath ? markupViewportTarget(appTemplatePath) : undefined;
   }
 
   const layoutPath = await findConfigFile(root, [

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -2,6 +2,8 @@ export type FrameworkId =
   | "nextjs"
   | "nuxt"
   | "react-vite"
+  | "svelte"
+  | "sveltekit"
   | "tanstack-start"
   | "vue";
 export type Platform = "ios" | "android";

--- a/cli/test/adapters.test.ts
+++ b/cli/test/adapters.test.ts
@@ -1,15 +1,17 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { nextjsAdapter } from "../src/adapters/nextjs.js";
 import { nuxtAdapter } from "../src/adapters/nuxt.js";
 import { reactViteAdapter } from "../src/adapters/react-vite.js";
+import { svelteAdapter } from "../src/adapters/svelte.js";
+import { svelteKitAdapter } from "../src/adapters/sveltekit.js";
 import { tanstackStartAdapter } from "../src/adapters/tanstack-start.js";
 import { vueAdapter } from "../src/adapters/vue.js";
 import { configureCapacitor } from "../src/capacitor/configure.js";
-import { loadProject } from "../src/core/project.js";
+import { loadProject, pathExists } from "../src/core/project.js";
 
 test("configures a standard Next.js project", async () => {
   const root = await createProject({
@@ -137,6 +139,229 @@ test("configures a standard React Vite project without changing it", async () =>
   assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
 });
 
+test("configures a standard Svelte Vite project without changing it", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/vite-plugin-svelte": "^7.0.0",
+      svelte: "^5.0.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  const packageJsonPath = path.join(root, "package.json");
+  const initialPackageJson = await readFile(packageJsonPath, "utf8");
+  const project = await loadProject(root);
+
+  assert.equal(svelteAdapter.detect(project), true);
+  assert.deepEqual(await svelteAdapter.validate(project), []);
+
+  const result = await svelteAdapter.configure(project, false);
+
+  assert.equal(await svelteAdapter.resolveWebDir(project), "dist");
+  assert.deepEqual(result.disclaimers, []);
+  assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
+});
+
+test("configures the current SvelteKit Vite config for a Capacitor SPA", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/adapter-auto": "^7.0.0",
+      "@sveltejs/kit": "^2.63.0",
+      svelte: "^5.56.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  const configPath = path.join(root, "vite.config.ts");
+  await writeFile(
+    configPath,
+    [
+      'import adapter from "@sveltejs/adapter-auto";',
+      'import { sveltekit } from "@sveltejs/kit/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [",
+      "    sveltekit({",
+      "      compilerOptions: { runes: true },",
+      "      // adapter-auto only supports some environments.",
+      "      // If your environment is not supported, switch out the adapter.",
+      "      // See https://svelte.dev/docs/kit/adapters for more information.",
+      "      adapter: adapter(),",
+      "    }),",
+      "  ],",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  const project = await loadProject(root);
+  assert.equal(svelteKitAdapter.detect(project), true);
+  assert.equal(svelteAdapter.detect(project), false);
+  assert.deepEqual(await svelteKitAdapter.validate(project), []);
+  assert.equal(await svelteKitAdapter.resolveWebDir(project), "build");
+
+  const result = await svelteKitAdapter.configure(project, false);
+  const config = await readFile(configPath, "utf8");
+  const rootLayout = await readFile(
+    path.join(root, "src/routes/+layout.js"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  ) as {
+    devDependencies: Record<string, string>;
+  };
+
+  assert.match(config, /@sveltejs\/adapter-static/);
+  assert.doesNotMatch(config, /@sveltejs\/adapter-auto/);
+  assert.doesNotMatch(config, /adapter-auto only supports/);
+  assert.doesNotMatch(config, /If your environment is not supported/);
+  assert.match(config, /fallback: "index\.html"/);
+  assert.match(config, /compilerOptions: \{ runes: true \}/);
+  assert.equal(rootLayout, "export const ssr = false;\n");
+  assert.equal(packageJson.devDependencies["@sveltejs/adapter-auto"], undefined);
+  assert.equal(
+    packageJson.devDependencies["@sveltejs/adapter-static"],
+    "^3.0.0",
+  );
+  assert.match(result.disclaimers[0].details.join(" "), /remote functions/);
+});
+
+test("configures a legacy SvelteKit config and preserves static options", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/adapter-static": "^3.0.10",
+      "@sveltejs/kit": "^2.0.0",
+      svelte: "^5.0.0",
+      vite: "^7.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  await writeFile(
+    path.join(root, "vite.config.js"),
+    [
+      'import { sveltekit } from "@sveltejs/kit/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({ plugins: [sveltekit()] });",
+      "",
+    ].join("\n"),
+  );
+  const configPath = path.join(root, "svelte.config.js");
+  await writeFile(
+    configPath,
+    [
+      'import adapter from "@sveltejs/adapter-static";',
+      "",
+      "const config = {",
+      "  kit: {",
+      "    adapter: adapter({",
+      '      pages: "build/mobile",',
+      '      assets: "build/mobile",',
+      "      precompress: true,",
+      "    }),",
+      "  },",
+      "};",
+      "",
+      "export default config;",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "src/routes/+layout.ts"),
+    "export const prerender = true;\nexport const ssr = true;\n",
+  );
+
+  const project = await loadProject(root);
+  assert.deepEqual(await svelteKitAdapter.validate(project), []);
+  assert.equal(
+    await svelteKitAdapter.resolveWebDir(project),
+    "build/mobile",
+  );
+
+  await svelteKitAdapter.configure(project, false);
+  const config = await readFile(configPath, "utf8");
+  const rootLayout = await readFile(
+    path.join(root, "src/routes/+layout.ts"),
+    "utf8",
+  );
+
+  assert.match(config, /pages: "build\/mobile"/);
+  assert.match(config, /assets: "build\/mobile"/);
+  assert.match(config, /precompress: true/);
+  assert.match(config, /fallback: "index\.html"/);
+  assert.match(rootLayout, /prerender = true/);
+  assert.match(rootLayout, /ssr = false/);
+});
+
+test("rejects split SvelteKit adapter-static output directories", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/adapter-static": "^3.0.0",
+      "@sveltejs/kit": "^2.0.0",
+      svelte: "^5.0.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  await writeFile(
+    path.join(root, "vite.config.ts"),
+    [
+      'import adapter from "@sveltejs/adapter-static";',
+      'import { sveltekit } from "@sveltejs/kit/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [sveltekit({",
+      '    adapter: adapter({ pages: "pages", assets: "assets" }),',
+      "  })],",
+      "});",
+      "",
+    ].join("\n"),
+  );
+
+  await assert.rejects(
+    async () => svelteKitAdapter.resolveWebDir(await loadProject(root)),
+    /pages and assets to use the same output directory/,
+  );
+});
+
+test("warns when SvelteKit server route files are present", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/adapter-auto": "^7.0.0",
+      "@sveltejs/kit": "^2.0.0",
+      svelte: "^5.0.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  await writeFile(
+    path.join(root, "vite.config.ts"),
+    [
+      'import adapter from "@sveltejs/adapter-auto";',
+      'import { sveltekit } from "@sveltejs/kit/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [sveltekit({ adapter: adapter() })],",
+      "});",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "src/routes/+page.server.ts"),
+    "export const load = () => ({});\n",
+  );
+
+  const diagnostics = await svelteKitAdapter.validate(await loadProject(root));
+
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].level, "warning");
+  assert.match(diagnostics[0].message, /src\/routes\/\+page\.server\.ts/);
+});
+
 test("resolves a custom React Vite output directory", async () => {
   const root = await createProject({
     dependencies: {
@@ -213,6 +438,20 @@ test("does not detect Nuxt as a standalone Vue project", async () => {
   });
 
   assert.equal(vueAdapter.detect(await loadProject(root)), false);
+});
+
+test("does not detect SvelteKit as standalone Svelte", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/kit": "^2.0.0",
+      svelte: "^5.0.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+
+  assert.equal(svelteAdapter.detect(await loadProject(root)), false);
+  assert.equal(svelteKitAdapter.detect(await loadProject(root)), true);
 });
 
 test("does not detect React frameworks as standalone React Vite projects", async () => {
@@ -351,6 +590,41 @@ test("Nuxt dry-run does not write framework configuration or package scripts", a
 
   assert.equal(await readFile(configPath, "utf8"), initialConfig);
   assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
+});
+
+test("SvelteKit dry-run does not write framework configuration or package dependencies", async () => {
+  const root = await createProject({
+    devDependencies: {
+      "@sveltejs/adapter-auto": "^7.0.0",
+      "@sveltejs/kit": "^2.0.0",
+      svelte: "^5.0.0",
+      vite: "^8.0.0",
+    },
+    scripts: { build: "vite build" },
+  });
+  const configPath = path.join(root, "vite.config.ts");
+  const packageJsonPath = path.join(root, "package.json");
+  const initialConfig = [
+    'import adapter from "@sveltejs/adapter-auto";',
+    'import { sveltekit } from "@sveltejs/kit/vite";',
+    'import { defineConfig } from "vite";',
+    "",
+    "export default defineConfig({",
+    "  plugins: [sveltekit({ adapter: adapter() })],",
+    "});",
+    "",
+  ].join("\n");
+  await writeFile(configPath, initialConfig);
+  const initialPackageJson = await readFile(packageJsonPath, "utf8");
+
+  await svelteKitAdapter.configure(await loadProject(root), true);
+
+  assert.equal(await readFile(configPath, "utf8"), initialConfig);
+  assert.equal(await readFile(packageJsonPath, "utf8"), initialPackageJson);
+  assert.equal(
+    await pathExists(path.join(root, "src/routes/+layout.js")),
+    false,
+  );
 });
 
 test("creates Capacitor config and package scripts", async () => {
@@ -529,6 +803,7 @@ test("merges serialized recommended defaults into a JSON Capacitor config", asyn
 
 async function createProject(packageJson: Record<string, unknown>) {
   const root = await mkdtemp(path.join(os.tmpdir(), "capstart-test-"));
+  await mkdir(path.join(root, "src/routes"), { recursive: true });
   await writeFile(
     path.join(root, "package.json"),
     `${JSON.stringify({ name: "example-app", ...packageJson }, null, 2)}\n`,

--- a/cli/test/framework-selection.test.ts
+++ b/cli/test/framework-selection.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 import { nextjsAdapter } from "../src/adapters/nextjs.js";
 import { nuxtAdapter } from "../src/adapters/nuxt.js";
 import { reactViteAdapter } from "../src/adapters/react-vite.js";
+import { svelteAdapter } from "../src/adapters/svelte.js";
+import { svelteKitAdapter } from "../src/adapters/sveltekit.js";
 import { tanstackStartAdapter } from "../src/adapters/tanstack-start.js";
 import { vueAdapter } from "../src/adapters/vue.js";
 import {
@@ -40,6 +42,8 @@ test("offers all frameworks when the detected framework is refused", async () =>
     "nextjs",
     "nuxt",
     "react-vite",
+    "svelte",
+    "sveltekit",
     "tanstack-start",
     "vue",
   ]);
@@ -99,6 +103,26 @@ test("accepts a detected React Vite project with --yes", async () => {
   assert.equal(adapter.id, "react-vite");
 });
 
+test("accepts a detected Svelte project with --yes", async () => {
+  const adapter = await chooseAdapter({
+    acceptDetected: true,
+    detected: [svelteAdapter],
+    interactive: false,
+  });
+
+  assert.equal(adapter.id, "svelte");
+});
+
+test("accepts a detected SvelteKit project with --yes", async () => {
+  const adapter = await chooseAdapter({
+    acceptDetected: true,
+    detected: [svelteKitAdapter],
+    interactive: false,
+  });
+
+  assert.equal(adapter.id, "sveltekit");
+});
+
 test("requires an explicit choice outside an interactive terminal", async () => {
   await assert.rejects(
     chooseAdapter({
@@ -112,7 +136,14 @@ test("requires an explicit choice outside an interactive terminal", async () => 
 
 function createPrompts(options: {
   confirm: boolean;
-  selected: "nextjs" | "nuxt" | "react-vite" | "tanstack-start" | "vue";
+  selected:
+    | "nextjs"
+    | "nuxt"
+    | "react-vite"
+    | "svelte"
+    | "sveltekit"
+    | "tanstack-start"
+    | "vue";
 }): FrameworkPrompts & {
   confirmCalls: number;
   lastOptions: string[];

--- a/cli/test/init-output.test.ts
+++ b/cli/test/init-output.test.ts
@@ -298,6 +298,97 @@ test("configures a React Vite project with safe area from end to end", async () 
   );
 });
 
+test("configures a SvelteKit project with safe area from end to end", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-output-test-"));
+  const cssPath = path.join(root, "src/app.css");
+  const appTemplatePath = path.join(root, "src/app.html");
+  const viteConfigPath = path.join(root, "vite.config.ts");
+  await mkdir(path.join(root, "src/routes"), { recursive: true });
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    appTemplatePath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  await writeFile(
+    viteConfigPath,
+    [
+      'import adapter from "@sveltejs/adapter-auto";',
+      'import { sveltekit } from "@sveltejs/kit/vite";',
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [sveltekit({ adapter: adapter() })],",
+      "});",
+      "",
+    ].join("\n"),
+  );
+  await writeFile(
+    path.join(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "example-app",
+        devDependencies: {
+          "@sveltejs/adapter-auto": "^7.0.0",
+          "@sveltejs/kit": "^2.0.0",
+          svelte: "^5.0.0",
+          vite: "^8.0.0",
+        },
+        scripts: { build: "vite build" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    await initCommand({
+      directory: root,
+      dryRun: false,
+      framework: "sveltekit",
+      interactive: false,
+      platforms: ["ios"],
+      safeArea: true,
+      skipBuild: true,
+      skipInstall: true,
+      skipNative: true,
+      yes: false,
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  const capacitorConfig = await readFile(
+    path.join(root, "capacitor.config.ts"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  ) as {
+    devDependencies: Record<string, string>;
+    scripts: Record<string, string>;
+  };
+
+  assert.match(await readFile(appTemplatePath, "utf8"), /viewport-fit=cover/);
+  assert.match(await readFile(viteConfigPath, "utf8"), /adapter-static/);
+  assert.match(await readFile(viteConfigPath, "utf8"), /fallback: "index\.html"/);
+  assert.equal(
+    await readFile(path.join(root, "src/routes/+layout.js"), "utf8"),
+    "export const ssr = false;\n",
+  );
+  assert.match(capacitorConfig, /webDir: "build"/);
+  assert.equal(packageJson.devDependencies["@sveltejs/adapter-auto"], undefined);
+  assert.equal(
+    packageJson.devDependencies["@sveltejs/adapter-static"],
+    "^3.0.0",
+  );
+  assert.equal(
+    packageJson.scripts["cap:sync"],
+    "npm run build && npm exec cap -- sync",
+  );
+});
+
 function stripAnsi(value: string): string {
   return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
 }

--- a/cli/test/safe-area.test.ts
+++ b/cli/test/safe-area.test.ts
@@ -160,6 +160,57 @@ test("adds safe area CSS and viewport fit to a React Vite project", async () => 
   );
 });
 
+test("adds safe area CSS and viewport fit to a Svelte Vite project", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/app.css");
+  const indexPath = path.join(root, "index.html");
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    indexPath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "svelte", false);
+  await configureSafeArea(project, "svelte", false);
+
+  assert.equal(
+    (await readFile(cssPath, "utf8")).match(/Capstart safe area insets/g)
+      ?.length,
+    1,
+  );
+  assert.equal(
+    (await readFile(indexPath, "utf8")).match(/viewport-fit=cover/g)?.length,
+    1,
+  );
+});
+
+test("adds safe area CSS and viewport fit to a SvelteKit project", async () => {
+  const root = await createProject();
+  const cssPath = path.join(root, "src/app.css");
+  const appTemplatePath = path.join(root, "src/app.html");
+  await writeFile(cssPath, "body { margin: 0; }\n");
+  await writeFile(
+    appTemplatePath,
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />\n',
+  );
+  const project = await loadProject(root);
+
+  await configureSafeArea(project, "sveltekit", false);
+  await configureSafeArea(project, "sveltekit", false);
+
+  assert.equal(
+    (await readFile(cssPath, "utf8")).match(/Capstart safe area insets/g)
+      ?.length,
+    1,
+  );
+  assert.equal(
+    (await readFile(appTemplatePath, "utf8")).match(/viewport-fit=cover/g)
+      ?.length,
+    1,
+  );
+});
+
 test("adds viewport fit to a Vue CLI public index", async () => {
   const root = await createProject();
   const cssPath = path.join(root, "src/assets/main.css");


### PR DESCRIPTION
## Summary

- add standalone Svelte + Vite framework detection and static output support
- add SvelteKit SPA configuration with `adapter-static`, `index.html` fallback, and runtime SSR disabled
- add safe-area support, compatibility warnings, tests, and documentation

## Impact

Capstart can now configure existing Svelte + Vite and compatible SvelteKit applications for Capacitor while preserving supported custom output directories and warning about server-only SvelteKit features.

## Validation

- `bun run typecheck` in `cli/`
- `bun test` in `cli/` (67 tests)
- `bun run build` in `cli/`
- real build using a current official SvelteKit project, producing `build/index.html`
- `bun run build` in `capstart-website/`, including prerender
- `git diff --check`