### PR TITLE
Fix create project directory

### DIFF
--- a/capstart-website/content/docs/cli.mdx
+++ b/capstart-website/content/docs/cli.mdx
@@ -110,6 +110,9 @@ Create a new boilerplate app:
 npx capstart create [directory] [options]
 ```
 
+When `directory` is omitted, Capstart asks for the app name and creates a new
+folder for it in the current directory.
+
 | Option | Purpose |
 | --- | --- |
 | `--app-id <id>` | Set the reverse-domain native app identifier |

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,6 +90,9 @@ Create a new app from the boilerplate:
 npx capstart create [directory] [options]
 ```
 
+When `directory` is omitted, Capstart asks for the app name and creates a new
+folder for it in the current directory.
+
 Examples:
 
 ```bash

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -21,7 +21,10 @@ program
 program
   .command("create")
   .description("Create a new app from the Capstart boilerplate.")
-  .argument("[directory]", "app directory", "my-app")
+  .argument(
+    "[directory]",
+    "app directory (defaults to a folder named after the app)",
+  )
   .option("--app-id <id>", "native application id, for example com.example.app")
   .option("--app-name <name>", "native application name")
   .option(

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -32,23 +32,27 @@ const defaultIgnoredTemplateParts = new Set([
 export interface CreateOptions {
   appId?: string;
   appName?: string;
-  directory: string;
+  directory?: string;
   interactive?: boolean;
   template?: string;
 }
 
 export async function createCommand(options: CreateOptions): Promise<void> {
-  const targetRoot = path.resolve(options.directory);
   const interactive =
     options.interactive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
-  const defaultName = createDefaultAppName(targetRoot);
+  const defaultName = options.directory
+    ? createDefaultAppName(path.resolve(options.directory))
+    : "my-app";
   const appName = await chooseAppName({
     defaultValue: defaultName,
     interactive,
     requested: options.appName,
   });
+  const targetRoot = path.resolve(
+    options.directory ?? createPackageName(appName),
+  );
   const appId = await chooseAppId({
-    defaultValue: createDefaultAppId(defaultName),
+    defaultValue: createDefaultAppId(appName),
     interactive,
     requested: options.appId,
   });

--- a/cli/test/create.test.ts
+++ b/cli/test/create.test.ts
@@ -72,6 +72,31 @@ test("creates an app from a local boilerplate template", async () => {
   assert.match(iosInfoPlist, /<string>Example Mobile<\/string>/);
 });
 
+test("creates a named project directory when no directory is provided", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "capstart-create-test-"));
+  const previousDirectory = process.cwd();
+
+  const originalLog = console.log;
+  console.log = () => {};
+  try {
+    process.chdir(root);
+    await createCommand({
+      appId: "com.example.mobile",
+      appName: "Example Mobile",
+      interactive: false,
+      template: boilerplatePath,
+    });
+  } finally {
+    process.chdir(previousDirectory);
+    console.log = originalLog;
+  }
+
+  const packageJson = JSON.parse(
+    await readFile(path.join(root, "example-mobile", "package.json"), "utf8"),
+  ) as { name: string };
+  assert.equal(packageJson.name, "example-mobile");
+});
+
 test("refuses to create an app in a non-empty directory", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "capstart-create-test-"));
   await writeFile(path.join(root, "existing.txt"), "existing\n");


### PR DESCRIPTION
## What changed

- derive the target folder from the app name when `capstart create` is run without a directory
- keep explicit `capstart create <directory>` usage compatible
- validate only the generated target directory instead of the current working directory
- derive the default native app ID from the selected app name
- document the no-directory behavior and add regression coverage

## Why

Running `capstart create` from a development directory could fail because the CLI treated the current directory as the project target and required it to be empty. Users should be able to run the command from a directory containing other projects and have Capstart create a new child folder for the app.

## Impact

`capstart create` now asks for the app name and creates the project in a normalized child folder such as `example-mobile/`. Passing an explicit directory continues to work as before.

## Validation

- `bun run typecheck`
- `bun test` (70 passing)
- `bun run build`
- `git diff --check`
